### PR TITLE
50 train with samples

### DIFF
--- a/alodataset/base_dataset.py
+++ b/alodataset/base_dataset.py
@@ -131,12 +131,11 @@ class BaseDataset(torch.utils.data.Dataset):
         super(BaseDataset, self).__init__(**kwargs)
         self.name = name
         self.sample = sample
-        if not self.sample:
-            self.items = []
-            self.dataset_dir = self.get_dataset_dir()
+        self.dataset_dir = self.get_dataset_dir()
         if self.sample:
             self.items = self.download_sample()
-            self.dataset_dir = os.path.join(self.vb_folder, "samples")
+        else:
+            self.items = []
         self.transform_fn = transform_fn
         self.ignore_errors = ignore_errors
         self.print_errors = print_errors
@@ -210,6 +209,9 @@ class BaseDataset(torch.utils.data.Dataset):
         """Look for dataset_dir based on the given name. To work properly a alodataset_config.json
         file must be save into /home/USER/.aloception/alodataset_config.json
         """
+        if self.sample:
+            return os.path.join(self.vb_folder, "samples")
+
         streaming_dt_config = os.path.join(self.vb_folder, "alodataset_config.json")
         if not os.path.exists(streaming_dt_config):
             self.set_dataset_dir(None)
@@ -245,19 +247,19 @@ class BaseDataset(torch.utils.data.Dataset):
 
         if dataset_dir is None:
             dataset_dir = _user_prompt(
-                f"{self.name} does not exist in config file."
+                f"{self.name} does not exist in config file. "
                 + "Do you want to download and use a sample?: (Y)es or (N)o: "
             )
-            if dataset_dir.lower() in ["y", "yes"]:
+            if dataset_dir.lower() in ["y", "yes"]:  # Download sample and change root directory
                 self.sample = True
-                return
+                return os.path.join(self.vb_folder, "samples")
             dataset_dir = _user_prompt(f"Please write a new root directory for {self.name} dataset: ")
             dataset_dir = os.path.expanduser(dataset_dir)
 
         # Save the config
         if not os.path.exists(dataset_dir):
             dataset_dir = _user_prompt(
-                f"[WARNING] {dataset_dir} path does not exists for dataset: {self.name}."
+                f"[WARNING] {dataset_dir} path does not exists for dataset: {self.name}. "
                 + "Please write a new directory:"
             )
             dataset_dir = os.path.expanduser(dataset_dir)

--- a/alodataset/coco_detection_dataset.py
+++ b/alodataset/coco_detection_dataset.py
@@ -80,7 +80,8 @@ class CocoDetectionDataset(BaseDataset, CocoDetectionSample):
         if "sample" not in kwargs:
             kwargs["sample"] = False
 
-        if not kwargs["sample"]:
+        self.sample = kwargs["sample"]
+        if not self.sample:
             assert img_folder is not None, "When sample = False, img_folder must be given."
             assert ann_file is not None, "When sample = False, ann_file must be given."
 
@@ -88,8 +89,8 @@ class CocoDetectionDataset(BaseDataset, CocoDetectionSample):
             dataset_dir = BaseDataset.get_dataset_dir(self)
             img_folder = os.path.join(dataset_dir, img_folder)
             ann_file = os.path.join(dataset_dir, ann_file)
+            kwargs["sample"] = self.sample
 
-        self.sample = kwargs["sample"]
         super(CocoDetectionDataset, self).__init__(name=name, root=img_folder, annFile=ann_file, **kwargs)
         if self.sample:
             return
@@ -282,9 +283,7 @@ def show_random_frame(coco_loader):
 def main():
     """Main"""
     logging.basicConfig(
-        level=logging.INFO,
-        format="[%(asctime)s][%(levelname)s] %(message)s",
-        datefmt="%d-%m-%y %H:%M:%S",
+        level=logging.INFO, format="[%(asctime)s][%(levelname)s] %(message)s", datefmt="%d-%m-%y %H:%M:%S",
     )
     log = logging.getLogger("aloception")
 

--- a/alonet/deformable_detr/train_on_coco.py
+++ b/alonet/deformable_detr/train_on_coco.py
@@ -15,9 +15,6 @@ def get_arg_parser():
     parser = ArgumentParser(conflict_handler="resolve")
     parser = alonet.common.add_argparse_args(parser)  # Common alonet parser
     parser = CocoDetection2Detr.add_argparse_args(parser)  # Coco detection parser
-    parser.add_argument(
-        "--use_sample", action="store_true", help="Download a sample for train process (Default: %(default)s)"
-    )
     parser = LitDeformableDetr.add_argparse_args(parser)  # LitDeformableDetr training parser
     # parser = pl.Trainer.add_argparse_args(parser) # Pytorch lightning Parser
     return parser

--- a/alonet/detr/train_on_coco.py
+++ b/alonet/detr/train_on_coco.py
@@ -9,9 +9,6 @@ def get_arg_parser():
     parser = ArgumentParser(conflict_handler="resolve")
     parser = alonet.common.add_argparse_args(parser)  # Common alonet parser
     parser = CocoDetection2Detr.add_argparse_args(parser)  # Coco detection parser
-    parser.add_argument(
-        "--use_sample", action="store_true", help="Download a sample for train process (Default: %(default)s)"
-    )
     parser = LitDetr.add_argparse_args(parser)  # LitDetr training parser
     # parser = pl.Trainer.add_argparse_args(parser) # Pytorch lightning Parser
     return parser
@@ -24,7 +21,7 @@ def main():
 
     # Init the Detr model with the dataset
     detr = LitDetr(args)
-    coco_loader = CocoDetection2Detr(args, sample=args.use_sample)
+    coco_loader = CocoDetection2Detr(args)
 
     detr.run_train(data_loader=coco_loader, args=args, project="detr", expe_name="detr_50")
 

--- a/alonet/raft/data_modules/chairs2raft.py
+++ b/alonet/raft/data_modules/chairs2raft.py
@@ -13,12 +13,13 @@ class Chairs2RAFT(Data2RAFT):
     def train_dataloader(self):
         split = Split.VAL if self.train_on_val else Split.TRAIN
         dataset = FlyingChairs2Dataset(split=split, transform_fn=self.train_transform, sample=self.sample)
+        self.sample = self.sample or dataset.sample
         sampler = SequentialSampler if self.sequential else RandomSampler
         return dataset.train_loader(batch_size=self.batch_size, num_workers=self.num_workers, sampler=sampler)
 
     def val_dataloader(self):
         dataset = FlyingChairs2Dataset(split=Split.VAL, transform_fn=self.val_transform, sample=self.sample)
-
+        self.sample = self.sample or dataset.sample
         return dataset.train_loader(batch_size=1, num_workers=self.num_workers, sampler=SequentialSampler)
 
 

--- a/alonet/raft/data_modules/data2raft.py
+++ b/alonet/raft/data_modules/data2raft.py
@@ -25,6 +25,9 @@ class Data2RAFT(pl.LightningDataModule):
         parser.add_argument("--num_workers", type=int, default=8, help="num_workers to use on the dataset")
         parser.add_argument("--limit_val_batches", type=_int_or_float_type, default=100)
         parser.add_argument("--sequential_sampler", action="store_true", help="sample data sequentially (no shuffle)")
+        parser.add_argument(
+            "--sample", action="store_true", help="Download a sample for train/val process (Default: %(default)s)"
+        )
         return parent_parser
 
     def train_transform(self, frame):

--- a/alonet/raft/train_on_chairs.py
+++ b/alonet/raft/train_on_chairs.py
@@ -9,9 +9,6 @@ def get_args_parser():
     parser = argparse.ArgumentParser(conflict_handler="resolve")
     parser = alonet.common.add_argparse_args(parser, add_pl_args=True)
     parser = Chairs2RAFT.add_argparse_args(parser)
-    parser.add_argument(
-        "--use_sample", action="store_true", help="Download a sample for train process (Default: %(default)s)"
-    )
     parser = LitRAFT.add_argparse_args(parser)
     return parser
 

--- a/unittest/test_train.py
+++ b/unittest/test_train.py
@@ -18,7 +18,7 @@ detr_args = get_argparse_defaults(detr_get_arg_parser())
 detr_args["weights"] = "detr-r50"
 detr_args["train_on_val"] = True
 detr_args["fast_dev_run"] = True
-detr_args["use_sample"] = True
+detr_args["sample"] = True
 
 
 @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**detr_args))
@@ -38,7 +38,7 @@ def_detr_args["weights"] = "deformable-detr-r50"
 def_detr_args["model_name"] = "deformable-detr-r50"
 def_detr_args["train_on_val"] = True
 def_detr_args["fast_dev_run"] = True
-def_detr_args["use_sample"] = True
+def_detr_args["sample"] = True
 
 
 @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**def_detr_args))
@@ -54,7 +54,7 @@ raft_args = get_argparse_defaults(raft_get_args_parser())
 raft_args["weights"] = "raft-things"
 raft_args["train_on_val"] = True
 raft_args["fast_dev_run"] = True
-raft_args["use_sample"] = True
+raft_args["sample"] = True
 
 
 @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**raft_args))


### PR DESCRIPTION
Solve bug #50

* Problem  because the `sample` flag was not being updated in the LightningData modules (COCO and RAFT). 
* Updated the `COCODetectionDetr` class logic to ensure the correct update of the `sample` flag.
* Update data connectors to get sample as argument in static functions
* Update unittest

Close #50 