### PR TITLE
Batch list improvment

### DIFF
--- a/alodataset/coco_detection_dataset.py
+++ b/alodataset/coco_detection_dataset.py
@@ -37,47 +37,47 @@ class CocoDetectionDataset(BaseDataset, CocoDetectionSample):
         **kwargs,
     ):
         """
-    Attributes
-    ----------
-    CATEGORIES : set
-        List of all unique tags read from the database
-    labels_names : list
-        List of labels according to their corresponding positions
-    prepare : :mod:`BaseDataset <base_dataset>`
+        Attributes
+        ----------
+        CATEGORIES : set
+            List of all unique tags read from the database
+        labels_names : list
+            List of labels according to their corresponding positions
+        prepare : :mod:`BaseDataset <base_dataset>`
 
-    Parameters
-    ----------
-    img_folder : str
-        Path to the image folder relative at `dataset_dir` (stored into the aloception config file)
-    ann_file : str
-        Path to the annotation file relative at `dataset_dir` (stored into the aloception config file)
-    name : str, optional
-        Key of database name in `alodataset_config.json` file, by default *coco*
-    return_masks : bool, optional
-        Include masks labels in the output, by default False
-    classes : list, optional
-        List of classes to be filtered in the annotation reading process, by default None
-    stuff_ann_file: str, optional
-        Additional annotations with new classes, by default None
-    **kwargs : dict
-        :mod:`BaseDataset <base_dataset>` optional parameters
+        Parameters
+        ----------
+        img_folder : str
+            Path to the image folder relative at `dataset_dir` (stored into the aloception config file)
+        ann_file : str
+            Path to the annotation file relative at `dataset_dir` (stored into the aloception config file)
+        name : str, optional
+            Key of database name in `alodataset_config.json` file, by default *coco*
+        return_masks : bool, optional
+            Include masks labels in the output, by default False
+        classes : list, optional
+            List of classes to be filtered in the annotation reading process, by default None
+        stuff_ann_file: str, optional
+            Additional annotations with new classes, by default None
+        **kwargs : dict
+            :mod:`BaseDataset <base_dataset>` optional parameters
 
-    Raises
-    ------
-    Exception
-        If a classes list is decided, each label must be inside of :attr:`CATEGORIES` list attribute
+        Raises
+        ------
+        Exception
+            If a classes list is decided, each label must be inside of :attr:`CATEGORIES` list attribute
 
-    Examples
-    --------
-        >>> coco_ds = CocoDetectionDataset(
-        ... img_folder = "val2017",
-        ... ann_file = "annotations/instances_val2017.json",
-        ... mode = "validation"
-        )
-        >>> frames = next(iter(coco_ds.train_loader()))
-        >>> frames = frames[0].batch_list(frames)
-        >>> frames.get_view(frames.boxes2d,).render()
-    """
+        Examples
+        --------
+            >>> coco_ds = CocoDetectionDataset(
+            ... img_folder = "val2017",
+            ... ann_file = "annotations/instances_val2017.json",
+            ... mode = "validation"
+            )
+            >>> frames = next(iter(coco_ds.train_loader()))
+            >>> frames = frames[0].batch_list(frames)
+            >>> frames.get_view(frames.boxes2d,).render()
+        """
 
         if "sample" not in kwargs:
             kwargs["sample"] = False
@@ -140,7 +140,7 @@ class CocoDetectionDataset(BaseDataset, CocoDetectionSample):
         self.items = self.ids
 
     def getitem(self, idx):
-        """ Get the :mod:`Frame <aloscene.frame>` corresponds to *idx* index
+        """Get the :mod:`Frame <aloscene.frame>` corresponds to *idx* index
 
         Parameters
         ----------
@@ -298,14 +298,7 @@ def show_random_frame(coco_loader):
 
 def main():
     """Main"""
-    # coco_dataset = CocoDetectionDataset(
-    #     img_folder="val2017",
-    #     stuff_ann_file="annotations/stuff_val2017.json",
-    #     ann_file="annotations/instances_val2017.json",
-    #     return_masks=True,
-    # )
     coco_dataset = CocoDetectionDataset(sample=True)
-
     for f, frames in enumerate(coco_dataset.train_loader(batch_size=2)):
         frames = Frame.batch_list(frames)
         frames.get_view().render()

--- a/alodataset/sintel_disparity_dataset.py
+++ b/alodataset/sintel_disparity_dataset.py
@@ -106,7 +106,8 @@ class SintelDisparityDataset(SintelBaseDataset):
 
 if __name__ == "__main__":
     dataset = SintelDisparityDataset(sample=True)
-    # show some frames at various indices
-    for idx in [1, 2, 5]:
-        frames = dataset.getitem(idx)["left"]
-        frames.get_view().render()
+
+    for f, frames in enumerate(dataset.train_loader(batch_size=2)):
+        frames = Frame.batch_list(frames)
+        frames["left"].get_view().render()
+        break

--- a/alodataset/sintel_flow_dataset.py
+++ b/alodataset/sintel_flow_dataset.py
@@ -96,7 +96,8 @@ class SintelFlowDataset(SintelBaseDataset):
 
 if __name__ == "__main__":
     dataset = SintelFlowDataset(sample=True)
-    # show some frames at various indices
-    for idx in [1, 2, 5]:
-        frames = dataset.getitem(idx)["left"]
-        frames.get_view().render()
+
+    for f, frames in enumerate(dataset.train_loader(batch_size=2)):
+        frames = Frame.batch_list(frames)
+        frames["left"].get_view().render()
+        break

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -25,7 +25,6 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         boxes2d: Union[dict, BoundingBoxes2D] = None,
         boxes3d: Union[dict, BoundingBoxes3D] = None,
         flow: Flow = None,
-        mask: Mask = None,
         segmentation: Mask = None,
         disparity: Disparity = None,
         normalization="255",
@@ -45,7 +44,6 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.add_label("boxes2d", boxes2d, align_dim=["B", "T"], mergeable=False)
         tensor.add_label("boxes3d", boxes3d, align_dim=["B", "T"], mergeable=False)
         tensor.add_label("flow", flow, align_dim=["B", "T"], mergeable=False)
-        tensor.add_label("mask", mask, align_dim=["B", "T"], mergeable=True)
         tensor.add_label("disparity", disparity, align_dim=["B", "T"], mergeable=True)
         tensor.add_label("segmentation", segmentation, align_dim=["B", "T"], mergeable=False)
 
@@ -98,19 +96,6 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
             boxes are attached to the frame, the boxes will be added to the set of boxes.
         """
         self._append_label("boxes3d", boxes_3d, name)
-
-    def append_mask(self, mask: Mask, name: str = None):
-        """Attach a mask to the frame.
-
-        Parameters
-        ----------
-        mask: aloscene.Mask
-            Mask to attached to the Frame
-        name: str
-            If none, the mask will be attached without name (if possible). Otherwise if no other unnamed
-            mask are attached to the frame, the mask will be added to the set of mask.
-        """
-        self._append_label("mask", mask, name)
 
     def append_flow(self, flow, name=None):
         """Attach a flow to the frame.

--- a/aloscene/mask.py
+++ b/aloscene/mask.py
@@ -28,7 +28,7 @@ class Mask(aloscene.tensors.SpatialAugmentedTensor):
             x = load_mask(x)
             kwargs["names"] = ("N", "H", "W")
         tensor = super().__new__(cls, x, *args, **kwargs)
-        tensor.add_label("labels", labels, align_dim=["N"], mergeable=True)
+        tensor.add_label("labels", labels, align_dim=["N"], mergeable=False)
         return tensor
 
     def __init__(self, x, *args, **kwargs):

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -859,17 +859,22 @@ class AugmentedTensor(torch.Tensor):
 
         Parameters
         ----------
-        offset_y: tuple
-            (percentage top_offset, percentage bottom_offset) Percentage based on the previous size
-        offset_x: tuple
-            (percentage left_offset, percentage right_offset) Percentage based on the previous size
-
+        offset_y: tuple of float or tuple of int
+            (percentage top_offset, percentage bottom_offset) Percentage based on the previous size If tuple of int
+            the absolute value will be converted to float (percentahe) before to be applied.
+        offset_x: tuple of float or tuple of int
+            (percentage left_offset, percentage right_offset) Percentage based on the previous size. If tuple of int
+            the absolute value will be converted to float (percentage) before to be applied.
 
         Returns
         -------
         croped : aloscene AugmentedTensor
             croped tensor
         """
+        if isinstance(offset_y[0], int) and isinstance(offset_y[1], int):
+            offset_y = (offset_y[0] / self.H, offset_y[1] / self.H)
+        if isinstance(offset_x[0], int) and isinstance(offset_x[1], int):
+            offset_x = (offset_x[0] / self.W, offset_x[1] / self.W)
 
         padded = self._pad(offset_y, offset_x, **kwargs)
         padded.recursive_apply_on_labels_(lambda label: self._pad_label(label, offset_y, offset_x, **kwargs))

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -346,7 +346,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         for spatial_tensor in n_sa_tensors:
             h_pad = (0, max_h - spatial_tensor.H)
             w_pad = (0, max_w - spatial_tensor.W)
-            padded_spatial_tensor = spatial_tensor.pad(h_pad, w_pad)
+            padded_spatial_tensor = spatial_tensor.pad(h_pad, w_pad, pad_boxes=pad_boxes)
             n_padded_list.append(padded_spatial_tensor)
 
         n_augmented_tensors = torch.cat(n_padded_list, dim=0)


### PR DESCRIPTION
In this merge request: 
- Make batch_list generic for all spatial augmented tensor (not only frame)
- Fixe rounding padding issue
- All Spatial Augmented tensor will now get a `mask` label (Before it was only on the Frame.)

@ragier 

Also you might need to update your samples from .aloception/samples to get everything working properly