### PR TITLE
Run from run_ID

### DIFF
--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -71,6 +71,7 @@ def add_argparse_args(parent_parser, add_pl_args=True, mode="training"):
     parser.add_argument("--project_run_id", type=str, help="Project related with the run ID to load")
     parser.add_argument("--expe_name", type=str, default=None, help="expe_name to be logged in wandb")
     parser.add_argument("--no_suffix", action="store_true", help="do not add date suffix to expe_name")
+    parser.add_argument("--strict", action="store_false", help="load from checkpoint to run a model with different weights (default True)")
 
     return parent_parser
 

--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -71,7 +71,7 @@ def add_argparse_args(parent_parser, add_pl_args=True, mode="training"):
     parser.add_argument("--project_run_id", type=str, help="Project related with the run ID to load")
     parser.add_argument("--expe_name", type=str, default=None, help="expe_name to be logged in wandb")
     parser.add_argument("--no_suffix", action="store_true", help="do not add date suffix to expe_name")
-    parser.add_argument("--nostrict", action="store_true", help="load from checkpoint to run a model with different weights (default False)")
+    parser.add_argument("--nostrict", action="store_true", help="load from checkpoint to run a model with different weights names (default False)")
 
     return parent_parser
 
@@ -123,7 +123,7 @@ def run_pl_training(
     resume_from_checkpoint = None
 
     if args.run_id is not None:
-        strict = not args.strict
+        strict = not args.nostrict
         run_id_project_dir = (
             project_dir if args.project_run_id is None else os.path.join(vb_folder(), f"project_{args.project_run_id}")
         )

--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -71,7 +71,7 @@ def add_argparse_args(parent_parser, add_pl_args=True, mode="training"):
     parser.add_argument("--project_run_id", type=str, help="Project related with the run ID to load")
     parser.add_argument("--expe_name", type=str, default=None, help="expe_name to be logged in wandb")
     parser.add_argument("--no_suffix", action="store_true", help="do not add date suffix to expe_name")
-    parser.add_argument("--strict", action="store_false", help="load from checkpoint to run a model with different weights (default True)")
+    parser.add_argument("--nostrict", action="store_false", help="load from checkpoint to run a model with different weights (default True)")
 
     return parent_parser
 

--- a/alonet/detr/train.py
+++ b/alonet/detr/train.py
@@ -47,6 +47,7 @@ class LitDetr(pl.LightningModule):
         super().__init__()
         # Update class attributes with args and kwargs inputs
         alonet.common.pl_helpers.params_update(self, args, kwargs)
+        self._init_kwargs_config.update({"model": model})
 
         # Load model
         if model is not None:


### PR DESCRIPTION
when launching a train after having loaded a checkpoint, parameters of the initial model were not kept and default parameters replaced them. It's fixed.
new parse argument "--nostrict" used if we want to run a model from a checkpoint, with different coefficients between the model and the model that generated the checkpoint.