### PR TITLE
fix bug load png image masks

### DIFF
--- a/aloscene/io/mask.py
+++ b/aloscene/io/mask.py
@@ -1,13 +1,12 @@
-import numpy as np
 import torch
 import torchvision
 from aloscene.io.utils.errors import InvalidSampleError
-
+from torchvision.io.image import ImageReadMode
 
 
 def load_mask_png(path):
     try:
-        image = torchvision.io.read_image(path).type(torch.float32) / 255.0
+        image = torchvision.io.read_image(path, ImageReadMode.GRAY).type(torch.float32) / 255.0
     except RuntimeError as e:
         raise InvalidSampleError(f"[Alodataset Warning] Invalid mask file: {path}")
     return image
@@ -16,7 +15,7 @@ def load_mask_png(path):
 def load_mask(path):
     if path.endswith(".zfd"):
         raise Exception("zfd format is not supported.")
-    elif path.endswith(".png"):
+    elif path.lower().endswith(".png"):
         return load_mask_png(path)
     else:
         raise ValueError()


### PR DESCRIPTION
Fix bug when aloscene.Mask try to use `io.load_image` function:

* It is not possible to read '.PNG' images (only '.png')
* In some cases RGBA images generate a tensor of 4 dimensions, Binary masks always should be a tensor of 1 dimension

