### PR TITLE
Try to import and raise error only if use with instruction

### DIFF
--- a/aloscene/utils/rotated_iou/cuda_op/cuda_ext.py
+++ b/aloscene/utils/rotated_iou/cuda_op/cuda_ext.py
@@ -15,7 +15,7 @@ class SortVertices(Function):
 
         if sort_vertices is None:
             print(sort_vertices_error)
-            Exception("To install: cd aloception/aloscene/utils/rotated_iou/cuda_op; python setup.py install --user ")
+            raise Exception("To install: cd aloception/aloscene/utils/rotated_iou/cuda_op; python setup.py install --user ")
 
         idx = sort_vertices.sort_vertices_forward(vertices, mask, num_valid)
         ctx.mark_non_differentiable(idx)


### PR DESCRIPTION
In this merge request:
- Trying to import sort_vertices
-  Only raise an error with instructions to install if the user, use the IOU 3D