### PR TITLE
Trt export profiling

### DIFF
--- a/alonet/torch2trt/TRTExecutor.py
+++ b/alonet/torch2trt/TRTExecutor.py
@@ -1,7 +1,9 @@
-import ctypes
+from collections import defaultdict
 from typing import Union
-import pycuda.autoinit as cuda_init
 import pycuda
+
+import pycuda.autoinit as cuda_init
+
 import tensorrt as trt
 from alonet.torch2trt.utils import allocate_buffers, execute_async, execute_sync
 
@@ -10,6 +12,18 @@ TRT_LOGGER = trt.Logger(trt.Logger.INFO)
 # ctypes.CDLL(MS_DEFORM_IM2COL_PLUGIN_LIB)
 # trt.init_libnvinfer_plugins(TRT_LOGGER, '')
 # PLUGIN_CREATORS = trt.get_plugin_registry().plugin_creator_list
+
+
+class CustomProfiler(trt.IProfiler):
+    def __init__(self):
+        trt.IProfiler.__init__(self)
+        self.reset()
+
+    def report_layer_time(self, layer_name, ms):
+        self.timing[layer_name].append(ms)
+
+    def reset(self):
+        self.timing = defaultdict(list)
 
 
 class TRTExecutor:
@@ -38,6 +52,7 @@ class TRTExecutor:
         stream: pycuda.driver.Stream = None,
         sync_mode: bool = False,
         verbose_logger: bool = False,
+        profiling: bool = False,
     ):
         """
         Parameters
@@ -65,6 +80,8 @@ class TRTExecutor:
         else:
             self.engine = engine
         self.context = self.engine.create_execution_context()
+        if profiling:
+            self.context.profiler = CustomProfiler()
         # TODO: test this mode later with DETR segmentaion
         if not has_dynamic_shape:
             self.inputs, self.outputs, self.bindings, self.stream = allocate_buffers(

--- a/alonet/torch2trt/onnx_hack.py
+++ b/alonet/torch2trt/onnx_hack.py
@@ -1,0 +1,97 @@
+import torch
+
+
+class scope_name_workaround(object):
+    """Workaround to preserve tensors scope names during onnx export"""
+
+    def __init__(self):
+        self.backup = None
+
+    def __enter__(self):
+        def _tracing_name(self_, tracing_state):
+            if not tracing_state._traced_module_stack:
+                return None
+            module = tracing_state._traced_module_stack[-1]
+            for name, child in module.named_children():
+                if child is self_:
+                    return name
+            return None
+
+        def _slow_forward(self_, *input, **kwargs):
+            tracing_state = torch._C._get_tracing_state()
+            if not tracing_state or isinstance(self_.forward, torch._C.ScriptMethod):
+                return self_.forward(*input, **kwargs)
+            if not hasattr(tracing_state, "_traced_module_stack"):
+                tracing_state._traced_module_stack = []
+            name = _tracing_name(self_, tracing_state)
+            if name:
+                tracing_state.push_scope("%s[%s]" % (self_._get_name(), name))
+            else:
+                tracing_state.push_scope(self_._get_name())
+            tracing_state._traced_module_stack.append(self_)
+            try:
+                result = self_.forward(*input, **kwargs)
+            finally:
+                tracing_state.pop_scope()
+                tracing_state._traced_module_stack.pop()
+            return result
+
+        self.backup = torch.nn.Module._slow_forward
+        setattr(torch.nn.Module, "_slow_forward", _slow_forward)
+
+    def __exit__(self, type, value, tb):
+        setattr(torch.nn.Module, "_slow_forward", self.backup)
+
+
+def get_scope_names(onnx_export_log, strict=True):
+    """Correspondance between tensor names given during ONNX with tensor scope name
+
+    Parameters
+    ----------
+    onnx_export_log : str
+        string output of redirected stdout during torch.onnx.export(..., verbose=True)
+
+    Returns
+    -------
+    number2scope: dict
+        dict of pairs <number_name: scope_name>. For exemple : {"34" : "AlexNet/Sequential[classifier]/Linear[4]"}
+    """
+    lines = onnx_export_log.split("\n")
+    number2scope = {}
+    scope_dict = {}
+    for line in lines:
+        if "scope: " in line:
+            name = line.split(":", 1)[0].strip().replace("%", "")
+            scope = line.split("scope: ", 1)[1].split(" # ")[0].strip()
+            if scope not in scope_dict:
+                scope_dict[scope] = 0
+            elif strict:
+                raise ValueError(f"Identical scope encountered more than once: {scope}")
+            else:
+                scope_dict[scope] += 1
+                scope = f"{scope}_{scope_dict[scope]}"
+            number2scope[name] = scope
+    return number2scope
+
+
+def rename_tensors_(graph, number2scope, verbose=False):
+    """Rename tensors in graph with their scope name instead of number name
+
+    Parameters
+    ----------
+    graph:
+        graph loaded with onnx_graphsurgeon
+    number2score: dict
+        dict of pairs <number_name: scope_name>. For exemple : {"34" : "AlexNet/Sequential[classifier]/Linear[4]"}
+
+    Returns
+    -------
+        modified graph (the graph is modified inplace)
+    """
+    dont_rename = [v.name for v in graph.inputs + graph.outputs]
+    for key, val in graph.tensors().items():
+        if key in number2scope and key not in dont_rename:
+            val.name = number2scope[key]
+            if verbose:
+                print(f"  changed {key} to {number2scope[key]}")
+    return graph


### PR DESCRIPTION
New features for model export to tensorRT and inference from engine.

In Class `alonet.torch2trt.BaseTRTExporter`:
- parameter `operator_export_type` can help specify the intermediate export to ONNX. This is useful when some torch operations do not have a direct equivalent in ONNX. This allows to export an invalid ONNX graph, that will be later modified to use a tensorRT plugin in place of the unknown operation. See `OperatorExportTypes.ONNX_FALLTHROUGH` description [here](https://pytorch.org/docs/stable/onnx.html#functions).
- parameter `use_scope_names` allows to keep meaningful node names during export to ONNX. Instead of being only numbers, the ONNX node names are derived from the module and submodule names. The implementation uses a workaround formulated [here](https://github.com/pytorch/pytorch/issues/33463), because scope_names are not supported by default in recent versions of pytorch.

In Class `alonet.torch2trt.TRTExecutor`:
- `profiling` parameter allows to attach a profiler to the tensorRT engine execution context. The individual timing of the layers of the engine are stored in the following dict `my_instance_of_TRTExecutor.context.profiler.timing`
