### PR TITLE
Panoptic2trt

### DIFF
--- a/alonet/__init__.py
+++ b/alonet/__init__.py
@@ -1,6 +1,4 @@
 ALONET_ROOT = "/".join(__file__.split("/")[:-1])
-from . import torch2trt
-
 from . import metrics
 from . import common
 from . import detr
@@ -11,3 +9,5 @@ from . import deformable_detr
 from . import callbacks
 
 from . import detr_panoptic
+
+from . import torch2trt

--- a/alonet/deformable_detr/trt_exporter.py
+++ b/alonet/deformable_detr/trt_exporter.py
@@ -4,8 +4,6 @@
 import argparse
 import os
 import torch
-import tensorrt as trt
-import ctypes
 import numpy as np
 import onnx_graphsurgeon as gs
 
@@ -59,7 +57,7 @@ class DeformableDetrTRTExporter(BaseTRTExporter):
 
         def handle_ops_MsDeformIm2ColTRT(graph: gs.Graph, node: gs.Node):
             inputs = node.inputs
-            inputs.pop()  # The last input is im2col_step = 64 (constant), our TRT plugin doesn't fully support this attribute
+            inputs.pop()  # The last input is im2col_step = 64 (constant), our TRT plugin doesn't fully support it
             outputs = node.outputs
             graph.layer(op="MsDeformIm2ColTRT", name=node.name + "_trt", inputs=inputs, outputs=outputs)
 
@@ -139,10 +137,10 @@ if __name__ == "__main__":
 
     if args.refinement:
         model_name = "deformable-detr-r50-refinement"
-        model = DeformableDetrR50Refinement(weights=model_name, tracing=True).eval()
+        model = DeformableDetrR50Refinement(weights=model_name, tracing=True, aux_loss=False).eval()
     else:
         model_name = "deformable-detr-r50"
-        model = DeformableDetrR50(weights=model_name, tracing=True).eval()
+        model = DeformableDetrR50(weights=model_name, tracing=True, aux_loss=False).eval()
 
     if args.onnx_path is None:
         args.onnx_path = os.path.join(vb_fodler(), "weights", model_name, model_name + ".onnx")

--- a/alonet/detr/trt_exporter.py
+++ b/alonet/detr/trt_exporter.py
@@ -48,7 +48,15 @@ if __name__ == "__main__":
     device = torch.device("cpu") if args.cpu else torch.device("cuda")
 
     input_shape = [3] + list(args.HW)
-    model = DetrR50(weights="detr-r50", tracing=True).eval().to(device)
+    model = DetrR50(
+        weights="detr-r50",
+        tracing=True,
+        aux_loss=False,
+        # return_dec_outputs=True,
+        # return_enc_outputs=True,
+        # return_bb_outputs=True,
+    )
+    model = model.eval().to(device)
     exporter = DetrTRTExporter(
         model=model, input_shapes=(input_shape,), input_names=["img"], device=device, **vars(args)
     )

--- a/alonet/detr_panoptic/detr_panoptic.py
+++ b/alonet/detr_panoptic/detr_panoptic.py
@@ -142,8 +142,6 @@ class PanopticHead(nn.Module):
                 frames, (dict, tuple)
             ), "Frames must be a dictionary or tuple with the corresponding outputs"
             if isinstance(frames, tuple):
-                names = ["pred_logits", "pred_boxes", "dec_outputs", "enc_outputs"]
-                names += [f"bb_lvl{lvl}_{n}_outputs" for lvl in range(4) for n in ["src", "mask", "pos"]]
                 names = [
                     "dec_outputs",
                     "enc_outputs",

--- a/alonet/detr_panoptic/detr_panoptic.py
+++ b/alonet/detr_panoptic/detr_panoptic.py
@@ -12,11 +12,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from alonet.detr.detr_r50 import DetrR50
 from alonet.detr_panoptic.nn import FPNstyleCNN
 from alonet.detr_panoptic.nn import MHAttentionMap
 from alonet.detr_panoptic.utils import get_mask_queries
-from alonet.detr.misc import assert_and_export_onnx
+from alonet.detr_panoptic.misc import assert_and_export_onnx
 
 import aloscene
 import alonet
@@ -31,8 +30,12 @@ class PanopticHead(nn.Module):
         Object detection module based on :mod:`DETR <alonet.detr.detr>` architecture
     freeze_detr : bool, optional
         Freeze :attr:`DETR_module` weights in train procedure, by default True
-    aux_loss: bool, optional
+    aux_loss : bool, optional
         Return aux outputs in forward step (if required), by default use :attr:`DETR_module.aux_loss` attribute value
+    return_pred_outputs : bool, optional
+        Return attr:`pred_logits` and attr:`pred_boxes` (detr outputs), by default True
+    return_detr_outputs : bool, optional
+        Return complementary detr outputs when calling :func: `forward`, by default False
     device : torch.device, optional
         Configure module in CPU or GPU, by default :attr:`torch.device("cpu")`
     weights : str, optional
@@ -40,7 +43,7 @@ class PanopticHead(nn.Module):
     fpn_list : list, optional
         Expected features backbone sizes from [layer1, layer2, layer3], by default [1024, 512, 256]
     strict_load_weights : bool
-        Load the weights (if any given) with strict = ``True`` (by default).
+        Load the weights (if any given) with strict = ``True`` (by default)
     tracing : bool, Optional
         Change model behavior to be exported as TorchScript, by default False
     """
@@ -52,6 +55,8 @@ class PanopticHead(nn.Module):
         DETR_module: alonet.detr.Detr,
         freeze_detr: bool = True,
         aux_loss: bool = None,
+        return_pred_outputs: bool = True,
+        return_detr_outputs: bool = False,
         device: torch.device = torch.device("cpu"),
         weights: str = None,
         fpn_list: list = [1024, 512, 256],
@@ -65,9 +70,10 @@ class PanopticHead(nn.Module):
         self.detr.return_dec_outputs = True
         self.detr.return_enc_outputs = True
         self.detr.return_bb_outputs = True
-        self.detr.aux_loss = aux_loss if aux_loss is not None else self.detr.aux_loss
-        self.detr.tracing = False  # Get normal outputs to export only PanopticHead
         self.tracing = tracing
+        self.return_detr_outputs = return_detr_outputs
+        self.return_pred_outputs = return_pred_outputs
+        self.detr.aux_loss = aux_loss if aux_loss is not None else self.detr.aux_loss
 
         if self.tracing and self.detr.aux_loss:
             raise AttributeError("When tracing = True, aux_loss must be False")
@@ -94,59 +100,60 @@ class PanopticHead(nn.Module):
             else:
                 raise ValueError(f"Unknown weights: '{weights}'")
 
+    @property
+    def tracing(self):
+        return self._tracing
+
+    @tracing.setter
+    def tracing(self, is_tracing):
+        self._tracing = is_tracing
+        self.detr.tracing = is_tracing
+
+    @assert_and_export_onnx(check_mean_std=True, input_mean_std=INPUT_MEAN_STD)
     def forward(self, frames: Union[aloscene.Frame, dict], get_filter_fn: Callable = None, **kwargs):
         """PanopticHead forward, that joint to the previous boxes predictions the new masks feature.
 
         Parameters
         ----------
         frames : Union[:mod:`Frames <aloscene.frame>`, dict]
-            Input frame to network or DETR/Deformable DETR outputs, with the following parameters :
+            Input frame or DETR/Deformable DETR outputs, with the following parameters :
 
-            - :attr:`pred_logits`: The classification logits (including no-object) for all queries.
-            - :attr:`pred_boxes`: The normalized boxes coordinates for all queries, represented as
+            - :attr:`pred_logits` : The classification logits (including no-object) for all queries.
+            - :attr:`pred_boxes` : The normalized boxes coordinates for all queries, represented as
               (center_x, center_y, height, width). These values are normalized in [0, 1], relative to the size of
               each individual image (disregarding possible padding).
-            - :attr:`bb_outputs`: Backbone outputs, requered in this forward
-            - :attr:`enc_outputs`: Transformer encoder outputs, requered on this forward
-            - :attr:`dec_outputs`: Transformer decoder outputs, requered on this forward
+            - :attr:`enc_outputs` : Transformer encoder outputs.
+            - :attr:`dec_outputs` : Transformer decoder outputs.
+            - :attr:`bb_outputs` : Backbone outputs, in `attr`:`bb_lvl{i}_src_outputs`,`attr`:`bb_lvl{i}_mask_outputs`
+              and `attr`:`bb_lvl{i}_pos_outputs` format, with {i} the backbone level.
 
         get_filter_fn : Callable
-            Function that returns two parameters: the :attr:`dec_outputs` tensor filtered by a boolean mask per
-            batch. It is expected that the function will at least receive :attr:`frames` and :attr:`m_outputs`
-            parameters as input. By default the function used to this purpuse is :func:`get_outs_filter` from
-            based model.
+            Function that must return two parameters : the :attr:`dec_outputs` tensor filtered by a boolean mask per
+            batch (second output). It is expected that the function will at least receive :attr:`frames` and
+            :attr:`m_outputs` parameters as input. By default the function used to this purpuse is
+            :func:`get_outs_filter` from based model.
 
         Returns
         -------
         dict
-            It outputs a dict with the following elements:
+            Output  with the following elements:
 
-            - :attr:`pred_logits`: The classification logits (including no-object) for all queries.
-              Shape = [batch_size x num_queries x (num_classes + 1)]
-            - :attr:`pred_boxes`: The normalized boxes coordinates for all queries, represented as
-              (center_x, center_y, height, width). These values are normalized in [0, 1], relative to the size of
-              each individual image (disregarding possible padding). See PostProcess for information on how to
-              retrieve the unnormalized bounding box.
-            - :attr:`pred_masks`: Binary masks, each one to assign to predicted boxes.
+            - :attr:`pred_masks` : Binary masks, each one to assign to predicted boxes.
               Shape = [batch_size x num_queries x H // 4 x W // 4]
-            - :attr:`bb_outputs`: Backbone outputs, requered in this forward
-            - :attr:`enc_outputs`: Transformer encoder outputs, requered on this forward
-            - :attr:`dec_outputs`: Transformer decoder outputs, requered on this forward
-            - :attr:`pred_masks_info`: Parameters to use in inference procedure
-            - :attr:`aux_outputs`: Optional, only returned when auxilary losses are activated. It is a list of
+            - :attr:`pred_masks_info` : Parameters to use in inference procedure
+            - :attr:`aux_outputs` : Optional, only returned when auxilary losses are activated. It is a list of
               dictionnaries containing the two above keys for each decoder layer.
+            - **:attr:`DETR_outputs`, such as :attr:`pred_logits` and :attr:`pred_boxes`.
         """
         # DETR model forward to obtain box embeddings
-        if self.tracing:
-            assert isinstance(frames, dict), "Frames must be a dictionary encode/decode/backbone tensors"
-            out = frames
+        if self.tracing and isinstance(frames, dict):  # Expected export only panoptic Head (without detr)
+            assert all([x in frames for x in ["dec_outputs", "enc_outputs", "bb_lvl3_mask_outputs"]])
+            assert all([x in frames for x in [f"bb_lvl{i}_src_outputs" for i in range(4)]])
+            detr_out = frames  # Expected encode/decode/backbone tensors in frames"
         else:
-            assert isinstance(frames, aloscene.Frame), "Frames must be a aloscene.Frame instance"
-            out = self.detr(frames, **kwargs)
+            detr_out = self.detr_forward(frames, **kwargs)
 
-        # features, _ = out["bb_outputs"]
-        # proj_src, mask = features[-1][0], features[-1][1]
-        proj_src, mask = out["bb_lvl3_src_outputs"], out["bb_lvl3_mask_outputs"]
+        proj_src, mask = detr_out["bb_lvl3_src_outputs"], detr_out["bb_lvl3_mask_outputs"]
         bs = proj_src.shape[0]
 
         if not self.tracing:
@@ -154,29 +161,54 @@ class PanopticHead(nn.Module):
             get_filter_fn = get_filter_fn or (
                 lambda *args, **kwargs: get_mask_queries(*args, model=self.detr, **kwargs)
             )
-            dec_outputs, filters = get_filter_fn(frames=frames, m_outputs=out, **kwargs)
+            dec_outputs, filters = get_filter_fn(frames=frames, m_outputs=detr_out, **kwargs)
         else:
-            # Assume that boxes were filtered previosly.
-            dec_outputs, filters = out["dec_outputs"], None
+            # Assume that boxes were filtered previosly / Pass all boxes through network
+            dec_outputs, filters = detr_out["dec_outputs"], None
             dec_outputs = dec_outputs[len(dec_outputs) - 1]  # Indexing -1 doesn't work well in torch2onnx
 
         # Use box embeddings as input of Multi Head attention
-        bbox_mask = self.bbox_attention(dec_outputs, out["enc_outputs"], mask=mask)
+        bbox_mask = self.bbox_attention(dec_outputs, detr_out["enc_outputs"], mask=mask)
 
         # And then, use MHA ouput as input of FPN-style CNN. proj_src = input_proj(features[-1][0])
-        # seg_masks = self.mask_head(proj_src, bbox_mask, [features[i][0] for i in range(3)[::-1]])
-        seg_masks = self.mask_head(proj_src, bbox_mask, [out[f"bb_lvl{i}_src_outputs"] for i in range(3)[::-1]])
+        seg_masks = self.mask_head(proj_src, bbox_mask, [detr_out[f"bb_lvl{i}_src_outputs"] for i in range(3)[::-1]])
+        seg_masks = seg_masks.view(bs, bbox_mask.shape[1], seg_masks.shape[-2], seg_masks.shape[-1])
 
-        out["pred_masks"] = seg_masks.view(bs, bbox_mask.shape[1], seg_masks.shape[-2], seg_masks.shape[-1])
+        # Make output
+        forward_head = self.forward_head(seg_masks, detr_outputs=detr_out)
 
         if self.tracing:  # Return the DETR output + pred_masks if tracing = False
-            output_named = namedtuple("m_outputs", "pred_masks")
-            out = output_named(out["pred_masks"])
+            output = namedtuple("m_outputs", forward_head.keys())
+            forward_head = output(*forward_head.values())
         else:
-            out["pred_masks_info"] = {"frame_size": frames.shape[-2:], "filters": filters}
+            forward_head["pred_masks_info"] = {"frame_size": frames.shape[-2:], "filters": filters}
+        return forward_head
+
+    def forward_head(self, pred_masks: torch.Tensor, detr_outputs: dict, **kwargs):
+        """Make the final dictionnary output.
+
+        Parameters
+        ----------
+        pred_masks : torch.Tensor
+            Masks pred by panoptic forward
+        detr_outputs : dict
+            DETR outputs to append
+
+        Returns
+        -------
+        dict
+            Output describe in :func:`forward` function
+        """
+
+        # Minimal outputs
+        out = {"pred_masks": pred_masks}
+        if self.return_pred_outputs:
+            out.update({"pred_logits": detr_outputs["pred_logits"], "pred_boxes": detr_outputs["pred_boxes"]})
+
+        if self.return_detr_outputs:
+            out.update({key: val for key, val in detr_outputs.items() if key not in ["pred_logits", "pred_boxes"]})
         return out
 
-    @assert_and_export_onnx(check_mean_std=True, input_mean_std=INPUT_MEAN_STD)
     def detr_forward(self, frames: aloscene.Frame, **kwargs):
         """DETR module forward
 
@@ -191,10 +223,15 @@ class PanopticHead(nn.Module):
         dict
             Outputs from the :func:`DETR forward <alonet.detr.detr.Detr.forward>`
         """
-        return self.detr(frames, **kwargs)
+        detr_outputs = self.detr(frames, **kwargs)
+        if self.tracing and isinstance(detr_outputs, tuple):  # Expected namedtuple
+            detr_outputs = detr_outputs._asdict()  # namedtuple to dict
+        return detr_outputs
 
     @torch.no_grad()
-    def inference(self, forward_out: Dict, maskth: float = 0.5, filters: list = None, **kwargs):
+    def inference(
+        self, forward_out: Dict, maskth: float = 0.5, filters: list = None, frame_size: tuple = None, **kwargs
+    ):
         """Given the model forward outputs, this method will return a set of
         :mod:`BoundingBoxes2D <aloscene.bounding_boxes_2d>` and :mod:`Mask <aloscene.mask>`, with its corresponding
         :mod:`Labels <aloscene.labels>` per object detected.
@@ -207,6 +244,8 @@ class PanopticHead(nn.Module):
             Threshold value to binarize the masks, by default 0.5
         filters : list, optional
             List of filter to select the query predicting an object, by default None
+        frame_size : tuple, optional
+            HW tuple to resize the masks, by default value given in :attr:`forward_out["pred_masks_info"]`
 
         Returns
         -------
@@ -215,10 +254,23 @@ class PanopticHead(nn.Module):
         :mod:`Mask <aloscene.mask>`
             Binary masks from PanopticHead, one for each box.
         """
-        # Get boxes from detr inference
-        filters = filters or forward_out["pred_masks_info"]["filters"]
-        frame_size = forward_out["pred_masks_info"]["frame_size"]
-        preds_boxes = self.detr.inference(forward_out, filters=filters, **kwargs)
+        # Get boxes from detr inference and filters
+        m_info = forward_out.get("pred_masks_info")
+        b_filters = filters or self.detr.get_outs_filter(m_outputs=forward_out, **kwargs)
+        m_filters = filters or (m_info.get("filters") if isinstance(m_info, dict) else None)
+        if m_filters is None:
+            if forward_out["pred_masks"].shape[1] == forward_out["pred_boxes"].shape[1]:
+                # Masks not filtered: Index given by bbox position
+                b, nq = forward_out["pred_boxes"].shape[:2]
+                m_filters = [forward_out["pred_boxes"].new_ones(nq).bool()] * b
+            else:
+                # Assume that masks were filtered in the following order (bbox_f => boxes filtered):
+                # [bbox_f[0] -> mask[0], bbox_f[1] -> mask[1], ..., bbox_f[N] -> mask[N]]
+                m_filters = b_filters
+
+        frame_size = frame_size or (m_info.get("frame_size") if isinstance(m_info, dict) else None)
+        frame_size = frame_size or forward_out["pred_masks"].shape[-2:]  # Not reshape
+        preds_boxes = self.detr.inference(forward_out, filters=b_filters, **kwargs)
 
         # Procedure to get information about masks
         outputs_masks = forward_out["pred_masks"].squeeze(2)
@@ -228,27 +280,25 @@ class PanopticHead(nn.Module):
             outputs_masks = outputs_masks.view(outputs_masks.shape[0], 0, *frame_size)
 
         # Keep high scores for one-hot encoding
-        # outputs_masks = (outputs_masks.sigmoid() > maskth).type(torch.long)
         outputs_masks = F.threshold(outputs_masks.sigmoid(), maskth, 0.0)
 
         # Transform predictions in aloscene.Mask
         preds_masks = []
         zero_masks = torch.zeros(*frame_size, device=outputs_masks.device, dtype=torch.long)
-        for boxes, masks, b_filter, m_filter in zip(
-            preds_boxes, outputs_masks, filters, forward_out["pred_masks_info"]["filters"]
-        ):
+        for boxes, masks, b_filter, m_filter in zip(preds_boxes, outputs_masks, b_filters, m_filters):
+
             # One shot encoding, to keep the high score class
-            masks = torch.cat([zero_masks.unsqueeze(0), masks], dim=0)  # Add zero mask to null result
+            null_values = (~masks.bool()).all(dim=0, keepdim=True)  # Pixels without a score > maskth
             onehot_masks = torch.zeros_like(masks)
             onehot_masks.scatter_(0, masks.argmax(dim=0, keepdim=True), 1)
-            masks = onehot_masks[1:].type(torch.long)  # Remove layer added
+            masks = onehot_masks.type(torch.long) * (~null_values)  # One-hot encoding with threshold
 
             # Boxes/masks alignment
             align_masks = []
             m_filter = torch.where(m_filter)[0]
             for ib in torch.where(b_filter)[0]:
                 im = (ib == m_filter).nonzero()
-                if im.numel() > 0:
+                if im.numel() > 0 and im.item() < len(masks):
                     align_masks.append(masks[im.item()])
                 else:
                     align_masks.append(zero_masks)
@@ -266,29 +316,31 @@ class PanopticHead(nn.Module):
 
 
 def main(image_path):
+    from alonet.detr import DetrR50Finetune
+
     device = torch.device("cuda")
 
     # Load model
-    model = PanopticHead(DetrR50(num_classes=250), weights="detr-r50-panoptic")
-    model.to(device)
+    model = PanopticHead(DetrR50Finetune(num_classes=250), weights="detr-r50-panoptic")
+    model.to(device).eval()
 
     # Open and prepare a batch for the model
     frame = aloscene.Frame(image_path).norm_resnet()
     frames = aloscene.Frame.batch_list([frame])
     frames = frames.to(device)
 
-    # Pred of size (B, NQ, H//4, W//4)
+    # GPU warm up
+    [model(frames) for _ in range(3)]
+
+    tic = time.time()
     with torch.no_grad():
-        # Measure inference time
-        tic = time.time()
         [model(frames) for _ in range(20)]
-        toc = time.time()
-        print(f"{(toc - tic)/20*1000} ms")
+    toc = time.time()
+    print(f"{(toc - tic)/20*1000} ms")
 
-        # Predict boxes
-        m_outputs = model(frames, threshold=0.5, background_class=250)
-
-    pred_boxes, pred_masks = model.inference(m_outputs)
+    # Predict boxes/masks
+    m_outputs = model(frames)  # Pred of size (B, NQ, H//4, W//4)
+    pred_boxes, pred_masks = model.inference(m_outputs, frame_size=frames.HW, threshold=0.85)
 
     # Add and display the boxes/masks predicted
     frame.append_boxes2d(pred_boxes[0], "pred_boxes")

--- a/alonet/detr_panoptic/misc.py
+++ b/alonet/detr_panoptic/misc.py
@@ -1,0 +1,39 @@
+from typing import Union
+import torch
+from aloscene import Frame
+from functools import wraps
+
+
+def assert_and_export_onnx(check_mean_std=False, input_mean_std=None):
+    def decorator(forward):
+        @wraps(forward)
+        def wrapper(instance, frames: Union[torch.Tensor, Frame], is_export_onnx=False, *args, **kwargs):
+            # A little hack: we use is_export_onnx=None and is_tracing=None as True when exporting onnx
+            # because torch.onnx.export accepts only torch.Tensor or None
+            if hasattr(instance, "tracing") and instance.tracing:
+                assert isinstance(frames, (torch.Tensor, dict))
+                if isinstance(frames, torch.Tensor):
+                    assert frames.shape[1] == 4  # Image input: expected rgb 3 + mask 1
+                else:
+                    # Image in DETR format, with fields at least:
+                    assert all([x in frames for x in ["dec_outputs", "enc_outputs", "bb_lvl3_mask_outputs"]])
+                    assert all([x in frames for x in [f"bb_lvl{i}_src_outputs" for i in range(4)]])
+                kwargs["is_tracing"] = None
+                if is_export_onnx is None:
+                    return forward(instance, frames, is_export_onnx=None, **kwargs)
+            else:
+                if isinstance(frames, list):
+                    frames = Frame.batch_list(frames)
+                assert isinstance(frames, Frame)
+                assert frames.normalization == "resnet"
+                assert frames.names == ("B", "C", "H", "W")
+                assert frames.mask is not None
+                assert frames.mask.names == ("B", "C", "H", "W")
+                if check_mean_std and input_mean_std is not None:
+                    assert frames.mean_std[0] == input_mean_std[0]
+                    assert frames.mean_std[1] == input_mean_std[1]
+            return forward(instance, frames, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/alonet/detr_panoptic/nn/FPNstyle.py
+++ b/alonet/detr_panoptic/nn/FPNstyle.py
@@ -10,7 +10,7 @@ from torch import nn, Tensor
 
 
 def _expand(tensor, length: int):
-    return tensor.unsqueeze(1).repeat(1, int(length), 1, 1, 1).flatten(0, 1)
+    return tensor.unsqueeze(1).repeat(1, length, 1, 1, 1).flatten(0, 1)
 
 
 class FPNstyleCNN(nn.Module):

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 
     # 2. Export PanopticHead engine
     args.onnx_path = pan_onnx_path
-    profile = {"dec_outputs": [(6, 1, 0, 256), (6, 1, 10, 256), (6, 1, 100, 256)]} if args.split_engines else None
+    profile = {"dec_outputs": [(6, 1, 1, 256), (6, 1, 10, 256), (6, 1, 100, 256)]} if args.split_engines else None
     exporter = PanopticTRTExporter(
         model=model,
         input_shapes=(input_shape,),

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -3,32 +3,34 @@
 
 import argparse
 import os
-import io
 import torch
 import onnx
 import onnx_graphsurgeon as gs
-from contextlib import ExitStack, redirect_stdout
 
-from alonet.torch2trt.onnx_hack import get_scope_names, rename_nodes_, rename_tensors_, scope_name_workaround
+from alonet.torch2trt.onnx_hack import rename_nodes_
 from alonet.torch2trt import BaseTRTExporter
 from aloscene import Frame
 
 
 class PanopticTRTExporter(BaseTRTExporter):
-    def __init__(self, *args, num_query: int = None, **kwargs):
+    def __init__(self, *args, num_query: int = None, export_with_detr: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.custom_opset = None
         if self.input_names is None:  # Default inputs
-            self.input_names = (
-                "dec_outputs",
-                "enc_outputs",
-                "bb_lvl0_src_outputs",
-                "bb_lvl1_src_outputs",
-                "bb_lvl2_src_outputs",
-                "bb_lvl3_src_outputs",
-                "bb_lvl3_mask_outputs",
-            )
+            if export_with_detr:
+                self.input_names = ("img",)
+            else:
+                self.input_names = (
+                    "dec_outputs",
+                    "enc_outputs",
+                    "bb_lvl0_src_outputs",
+                    "bb_lvl1_src_outputs",
+                    "bb_lvl2_src_outputs",
+                    "bb_lvl3_src_outputs",
+                    "bb_lvl3_mask_outputs",
+                )
         self.num_query = num_query  # Fix num_query to static value
+        self.export_with_detr = export_with_detr
 
     def adapt_graph(self, graph: gs.Graph):
         # return graph  # Not optimize
@@ -58,74 +60,20 @@ class PanopticTRTExporter(BaseTRTExporter):
         x = torch.rand(shape, dtype=torch.float32)
         x = Frame(x, names=["C", "H", "W"]).norm_resnet()
         x = Frame.batch_list([x] * self.batch_size).to(self.device)
+        x = torch.cat((x.as_tensor(), x.mask.as_tensor()), dim=1)  # [b, 4, H, W]
 
-        with torch.no_grad():
-            tensor_input = self.model.detr(x)  # Get Detr outputs expected
+        if self.export_with_detr:  # Image as input = export detr + panoptic
+            tensor_input = (x,)
+        else:  # dict as input = export only panoptic
+            with torch.no_grad():
+                tensor_input = self.model.detr_forward(x)  # Get Detr outputs expected
 
-        if self.num_query is not None:  # Fix static num queries
-            tensor_input["dec_outputs"] = tensor_input["dec_outputs"][:, :, : self.num_query]
+            if self.num_query is not None:  # Fix static num queries
+                tensor_input["dec_outputs"] = tensor_input["dec_outputs"][:, :, : self.num_query]
 
-        # return (tuple(tensor_input[iname].contiguous() for iname in self.input_names),), {}
-        return {iname: tensor_input[iname].contiguous() for iname in self.input_names}, {}
+            tensor_input = {iname: tensor_input[iname].contiguous() for iname in self.input_names}
 
-    def _torch2onnx(self):
-        # Prepare dummy input for tracing
-        inputs, kwargs = self.prepare_sample_inputs()
-
-        # Get sample inputs/outputs for later sanity check
-        with torch.no_grad():
-            m_outputs = self.model(inputs, **kwargs)
-        np_inputs = tuple(inputs[iname].cpu().numpy() for iname in self.input_names)
-        np_m_outputs = {}
-        output_names = (
-            m_outputs._fields if hasattr(m_outputs, "_fields") else ["out_" + str(i) for i in range(len(m_outputs))]
-        )
-        for key, val in zip(output_names, m_outputs):
-            if isinstance(val, torch.Tensor):
-                np_m_outputs[key] = val.cpu().numpy()
-        # print("Model output keys:", m_outputs.keys())
-
-        # Export to ONNX
-        with ExitStack() as stack:
-            # context managers necessary to redirect stdout and modify export trace to print scope
-            if self.use_scope_names:
-                buffer = stack.enter_context(io.StringIO())
-                stack.enter_context(redirect_stdout(buffer))
-                stack.enter_context(scope_name_workaround())
-            torch.onnx.export(
-                self.model,  # model being run
-                inputs,  # model input (or a tuple for multiple inputs)
-                self.onnx_path,  # where to save the model
-                export_params=True,  # store the trained parameter weights inside the model file
-                opset_version=13,  # the ONNX version to export the model to
-                do_constant_folding=self.do_constant_folding,  # whether to execute constant folding for optimization
-                verbose=self.verbose or self.use_scope_names,  # verbose mandatory in scope names procedure
-                input_names=self.input_names,  # the model's input names
-                output_names=output_names,
-                custom_opsets=self.custom_opset,
-                enable_onnx_checker=True,
-                operator_export_type=self.operator_export_type,
-                # dynamic_axes={
-                #     "dec_outputs": [2],  # Query dim must be dynamic
-                #     "pred_masks": [1],  # With query dynamic, pred_masks is dynamic to.
-                # },
-            )
-
-            if self.use_scope_names:
-                onnx_export_log = buffer.getvalue()
-
-        # rewrite onnx graph with new scope names
-        if self.use_scope_names:
-            # print(onnx_export_log)
-            number2scope = get_scope_names(onnx_export_log, strict=False)
-            graph = gs.import_onnx(onnx.load(self.onnx_path))
-            graph = rename_tensors_(graph, number2scope, verbose=True)
-            onnx.save(gs.export_onnx(graph), self.onnx_path)
-
-        print("Saved ONNX at:", self.onnx_path)
-        # empty GPU memory for later TensorRT optimization
-        torch.cuda.empty_cache()
-        return np_inputs, np_m_outputs
+        return tensor_input, {"is_export_onnx": None}
 
 
 if __name__ == "__main__":
@@ -140,33 +88,46 @@ if __name__ == "__main__":
         "--HW", type=int, nargs=2, default=[1280, 1920], help="Height and width of input image, by default %(default)s"
     )
     parser.add_argument("--cpu", action="store_true", help="Compile model in CPU, by default %(default)s")
+    parser.add_argument(
+        "--split_engines",
+        action="store_true",
+        help="Save DETR/Panoptic engines in different files, by default %(default)s",
+    )
     BaseTRTExporter.add_argparse_args(parser)
 
     args = parser.parse_args()
     device = torch.device("cpu") if args.cpu else torch.device("cuda")
     input_shape = [3] + list(args.HW)
-    pan_onnx_path = args.onnx_path or os.path.join(vb_fodler(), "weights", "detr-r50-panoptic", "panoptic-head.onnx")
+    pan_onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50-panoptic")
+    if args.split_engines:
+        pan_onnx_path = os.path.join(pan_onnx_path, "panoptic-head.onnx")
+    else:
+        pan_onnx_path = os.path.join(pan_onnx_path, "detr-r50-panoptic.onnx")
+    pan_onnx_path = args.onnx_path or pan_onnx_path
 
     model = PanopticHead(
         DETR_module=DetrR50(num_classes=250, background_class=None),
         weights="detr-r50-panoptic",
         tracing=True,
         aux_loss=False,
+        return_pred_outputs=not args.split_engines,
     )
     model = model.eval().to(device)
 
-    # 1. Export Detr engine
-    print("[INFO] Exporting DETR engine...")
-    args.onnx_path = os.path.join(os.path.split(pan_onnx_path)[0], "detr-r50.onnx")
-    model.detr.tracing = True
-    exporter = DetrTRTExporter(
-        model=model.detr, input_shapes=(input_shape,), input_names=["img"], device=device, **vars(args)
-    )
-    exporter.export_engine()
-    model.detr.tracing = False  # Required for next procedure
+    if args.split_engines:
+        # 1. Export Detr engine
+        print("\n[INFO] Exporting DETR engine...")
+        args.onnx_path = os.path.join(os.path.split(pan_onnx_path)[0], "detr-r50.onnx")
+        exporter = DetrTRTExporter(
+            model=model.detr, input_shapes=(input_shape,), input_names=["img"], device=device, **vars(args)
+        )
+        exporter.export_engine()
+
+        print("\n\n[INFO] Exporting PanopticHead engine...")
 
     # 2. Export PanopticHead engine
-    print("[INFO] Exporting PanopticHead engine...")
     args.onnx_path = pan_onnx_path
-    exporter = PanopticTRTExporter(model=model, input_shapes=(input_shape,), device=device, **vars(args))
+    exporter = PanopticTRTExporter(
+        model=model, input_shapes=(input_shape,), export_with_detr=not args.split_engines, device=device, **vars(args)
+    )
     exporter.export_engine()

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -58,7 +58,9 @@ class PanopticTRTExporter(BaseTRTExporter):
         x = torch.rand(shape, dtype=torch.float32)
         x = Frame(x, names=["C", "H", "W"]).norm_resnet()
         x = Frame.batch_list([x] * self.batch_size).to(self.device)
-        tensor_input = self.model.detr(x)  # Get Detr outputs expected
+
+        with torch.no_grad():
+            tensor_input = self.model.detr(x)  # Get Detr outputs expected
 
         if self.num_query is not None:  # Fix static num queries
             tensor_input["dec_outputs"] = tensor_input["dec_outputs"][:, :, : self.num_query]
@@ -73,7 +75,7 @@ class PanopticTRTExporter(BaseTRTExporter):
         # Get sample inputs/outputs for later sanity check
         with torch.no_grad():
             m_outputs = self.model(inputs, **kwargs)
-        np_inputs = tuple(inputs[iname].cpu().detach().numpy() for iname in self.input_names)
+        np_inputs = tuple(inputs[iname].cpu().numpy() for iname in self.input_names)
         np_m_outputs = {}
         output_names = (
             m_outputs._fields if hasattr(m_outputs, "_fields") else ["out_" + str(i) for i in range(len(m_outputs))]

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -1,0 +1,149 @@
+"""Helper class for exporting PyTorch model to TensorRT engine
+"""
+
+import argparse
+import os
+import io
+import numpy as np
+import torch
+import onnx
+import onnx_graphsurgeon as gs
+from contextlib import ExitStack, redirect_stdout
+
+from alonet.torch2trt.onnx_hack import get_scope_names, rename_nodes_, rename_tensors_, scope_name_workaround
+from alonet.detr_panoptic import PanopticHead
+from alonet.detr import DetrR50
+from alonet.torch2trt import BaseTRTExporter
+from aloscene import Frame
+
+
+class PanopticDetrTRTExporter(BaseTRTExporter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.custom_opset = None
+        if self.input_names is None:  # Default inputs
+            self.input_names = [
+                "dec_outputs",
+                "enc_outputs",
+                "bb_lvl0_src_outputs",
+                "bb_lvl1_src_outputs",
+                "bb_lvl2_src_outputs",
+                "bb_lvl3_src_outputs",
+                "bb_lvl3_mask_outputs",
+            ]
+
+    def adapt_graph(self, graph: gs.Graph):
+        # return graph
+
+        from onnxsim import simplify
+
+        # no need to modify graph
+        model = onnx.load(self.onnx_path)
+        check = False
+        model_simp, check = simplify(model)
+
+        if check:
+            print("\n[INFO] Simplified ONNX model validated. Graph optimized...")
+            graph = gs.import_onnx(model_simp)
+            graph.toposort()
+            graph.cleanup()
+        else:
+            print("\n[INFO] ONNX model was not validated.")
+
+        if self.use_scope_names:  # Rename nodes to correct profiling
+            graph = rename_nodes_(graph, True)
+        return graph
+
+    def prepare_sample_inputs(self):
+        assert len(self.input_shapes) == 1, "Panoptic takes only 1 input"
+        shape = self.input_shapes[0]
+        x = torch.rand(shape, dtype=torch.float32)
+        x = Frame(x, names=["C", "H", "W"]).norm_resnet()
+        x = Frame.batch_list([x] * self.batch_size).to(self.device)
+        tensor_input = self.model.detr(x)  # Get Detr outputs expected
+        return (tuple(tensor_input[iname] for iname in self.input_names),), {}
+
+    def _torch2onnx(self):
+        # Prepare dummy input for tracing
+        inputs, kwargs = self.prepare_sample_inputs()
+
+        # Get sample inputs/outputs for later sanity check
+        with torch.no_grad():
+            m_outputs = self.model(*inputs, **kwargs)
+        np_inputs = tuple(np.ascontiguousarray(np.array(i.cpu())) for i in inputs[0])
+        np_m_outputs = {}
+        output_names = (
+            m_outputs._fields if hasattr(m_outputs, "_fields") else ["out_" + str(i) for i in range(len(m_outputs))]
+        )
+        for key, val in zip(output_names, m_outputs):
+            if isinstance(val, torch.Tensor):
+                np_m_outputs[key] = val.cpu().numpy()
+        # print("Model output keys:", m_outputs.keys())
+
+        # Export to ONNX
+        with ExitStack() as stack:
+            # context managers necessary to redirect stdout and modify export trace to print scope
+            if self.use_scope_names:
+                buffer = stack.enter_context(io.StringIO())
+                stack.enter_context(redirect_stdout(buffer))
+                stack.enter_context(scope_name_workaround())
+            torch.onnx.export(
+                self.model,  # model being run
+                inputs,  # model input (or a tuple for multiple inputs)
+                self.onnx_path,  # where to save the model
+                export_params=True,  # store the trained parameter weights inside the model file
+                opset_version=13,  # the ONNX version to export the model to
+                do_constant_folding=self.do_constant_folding,  # whether to execute constant folding for optimization
+                verbose=self.verbose or self.use_scope_names,  # verbose mandatory in scope names procedure
+                input_names=self.input_names,  # the model's input names
+                output_names=output_names,
+                custom_opsets=self.custom_opset,
+                enable_onnx_checker=True,
+                operator_export_type=self.operator_export_type,
+            )
+
+            if self.use_scope_names:
+                onnx_export_log = buffer.getvalue()
+
+        # rewrite onnx graph with new scope names
+        if self.use_scope_names:
+            # print(onnx_export_log)
+            number2scope = get_scope_names(onnx_export_log, strict=False)
+            graph = gs.import_onnx(onnx.load(self.onnx_path))
+            graph = rename_tensors_(graph, number2scope, verbose=True)
+            onnx.save(gs.export_onnx(graph), self.onnx_path)
+
+        print("Saved ONNX at:", self.onnx_path)
+        # empty GPU memory for later TensorRT optimization
+        torch.cuda.empty_cache()
+        return np_inputs, np_m_outputs
+
+
+if __name__ == "__main__":
+    from alonet.common.weights import vb_fodler
+
+    # test script
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--HW", type=int, nargs=2, default=[1280, 1920], help="Height and width of input image, by default %(default)s"
+    )
+    parser.add_argument("--cpu", action="store_true", help="Compile model in CPU, by default %(default)s")
+    BaseTRTExporter.add_argparse_args(parser)
+
+    args = parser.parse_args()
+    if args.onnx_path is None:
+        args.onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50-panoptic", "panoptic-head.onnx")
+    device = torch.device("cpu") if args.cpu else torch.device("cuda")
+
+    input_shape = [3] + list(args.HW)
+    model = PanopticHead(
+        DETR_module=DetrR50(num_classes=250, background_class=None),
+        weights="detr-r50-panoptic",
+        tracing=True,
+        aux_loss=False,
+    )
+    model = model.eval().to(device)
+
+    exporter = PanopticDetrTRTExporter(model=model, input_shapes=(input_shape,), device=device, **vars(args))
+
+    exporter.export_engine()

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -73,7 +73,7 @@ class PanopticTRTExporter(BaseTRTExporter):
         # Get sample inputs/outputs for later sanity check
         with torch.no_grad():
             m_outputs = self.model(inputs, **kwargs)
-        np_inputs = tuple(inputs[iname].cpu().numpy() for iname in self.input_names)
+        np_inputs = tuple(inputs[iname].cpu().detach().numpy() for iname in self.input_names)
         np_m_outputs = {}
         output_names = (
             m_outputs._fields if hasattr(m_outputs, "_fields") else ["out_" + str(i) for i in range(len(m_outputs))]

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -257,7 +257,7 @@ class BaseTRTExporter:
         for out in m_outputs:
             diff = m_outputs[out].astype(float) - sample_outputs[out].astype(float)
             abs_err = np.abs(diff)
-            rel_err = np.abs(diff / sample_outputs[out])
+            rel_err = np.abs(diff / (sample_outputs[out] + 1e-6))  # Avoid div by zero
             print(out)
             print(f"\tmean: {abs_err.mean():.2e}\t{rel_err.mean():.2e}")
             print(f"\tmax: {abs_err.max():.2e}\t{rel_err.max():.2e}")

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -255,7 +255,7 @@ class BaseTRTExporter:
         m_outputs = model.execute()
         print("==== Absolute / relavtive error:")
         for out in m_outputs:
-            diff = m_outputs[out] - sample_outputs[out]
+            diff = m_outputs[out].astype(float) - sample_outputs[out].astype(float)
             abs_err = np.abs(diff)
             rel_err = np.abs(diff / sample_outputs[out])
             print(out)

--- a/alonet/torch2trt/onnx_hack.py
+++ b/alonet/torch2trt/onnx_hack.py
@@ -95,3 +95,48 @@ def rename_tensors_(graph, number2scope, verbose=False):
             if verbose:
                 print(f"  changed {key} to {number2scope[key]}")
     return graph
+
+
+def rename_nodes_(graph, verbose=False):
+    """Rename node names in graph with their outputs or inputs to improve timing measure.
+    Must be used after call :func:`rename_tensors_`
+
+    Parameters
+    ----------
+    graph:
+        graph loaded with onnx_graphsurgeon
+
+    Returns
+    -------
+        modified graph (the graph is modified inplace)
+    """
+    dont_rename = [v.name for v in graph.inputs + graph.outputs]
+
+    for node in graph.nodes:
+        if node.name not in dont_rename:
+            # Replace name by output name to include in profiling
+            node.name = node.outputs[0].name
+
+            # If the node does not have name, try to replace by inputs tensors to it
+            try:
+                id_node = int(node.name)
+                node_is_int = True
+            except:
+                node_is_int = False
+
+            if node_is_int:
+                for inode in node.inputs:
+                    try:  # Only for named inputs
+                        int(inode.name)
+                        inode_is_int = True
+                    except:
+                        inode_is_int = False
+
+                    # Input named, change tensor name
+                    if not inode_is_int:
+                        new_name = inode.name + "_" + str(id_node)
+                        if verbose:
+                            print(f"  changed {node.name} to {new_name}")
+                        node.name = new_name
+
+    return graph

--- a/alonet/torch2trt/utils.py
+++ b/alonet/torch2trt/utils.py
@@ -185,7 +185,7 @@ def allocate_buffers(context, stream=None, sync_mode=True):
         stream = cuda.Stream()
     for binding in context.engine:
         binding_idx = context.engine.get_binding_index(binding)
-        shape = context.get_binding_shape(binding_idx)
+        shape = context.engine.get_binding_shape(binding_idx)
         dtype = trt.nptype(context.engine.get_binding_dtype(binding))
         if is_dynamic(shape):
             # Not allocate buffers because is a dynamic binding

--- a/alonet/torch2trt/utils.py
+++ b/alonet/torch2trt/utils.py
@@ -72,18 +72,24 @@ def GiB(val):
     return val * 1 << 30
 
 
+def is_dynamic(shape: tuple):
+    return any(dim is None or dim < 0 for dim in shape)
+
+
 class HostDeviceMem(object):
     """
     Simple helper class to store useful data of an engine's binding
 
     Attributes
     ----------
-    host_mem: np.ndarray
+    host_mem : np.ndarray
         data stored in CPU
-    device_mem: pycuda.driver.DeviceAllocation
+    device_mem : pycuda.driver.DeviceAllocation
         represent data pointer in GPU
-    shape: tuple
-    dtype: np dtype
+    shape : tuple
+    dtype : np dtype
+    location : trt.TensorLocation
+        Device location information
     name: str
         name of the binding
     """
@@ -102,10 +108,60 @@ class HostDeviceMem(object):
         return self.__str__()
 
 
+class DynamicHostDeviceMem(HostDeviceMem):
+    """
+    Class to store useful data of an engine's binding. Allocate memory on each host setting
+
+    Attributes
+    ----------
+    host_mem : np.ndarray
+        data stored in CPU
+    device_mem : pycuda.driver.DeviceAllocation
+        represent data pointer in GPU
+    shape : tuple
+    dtype : np dtype
+    location : trt.TensorLocation
+        Device location information
+    name: str
+        name of the binding
+    """
+
+    @property
+    def host(self):
+        return self._host
+
+    @host.setter
+    def host(self, new_host):
+        if new_host is None:
+            self.release()
+        else:
+            self.allocate_mem(tuple(new_host.shape))
+        self._host = new_host
+
+    def allocate_mem(self, new_shape: tuple):
+        if self._host is None or not hasattr(self.shape, "__iter__") or tuple(new_shape) != tuple(self.shape):
+            # Allocate buffer with new shape, after release memory
+            self.release()
+            self.shape = new_shape
+            self._host = cuda.pagelocked_empty(trt.volume(self.shape), self.dtype)
+            self.device = cuda.mem_alloc(self._host.nbytes)  # New pointer
+
+    def release(self):
+        if hasattr(self, "device") and self.device is not None:
+            self.device.free()  # Freeze memory allocated
+        self.shape = None
+
+
 def allocate_buffers(context, stream=None, sync_mode=True):
     """
     Read bindings' information in ExecutionContext, create pagelocked np.ndarray in CPU,
     allocate corresponding memory in GPU.
+
+    Parameters
+    ----------
+    context : trt.IExecutionContext
+    stream : pycuda.driver.Stream, optional
+    sync_mode : bool, optional
 
     Returns
     -------
@@ -115,28 +171,96 @@ def allocate_buffers(context, stream=None, sync_mode=True):
         list of pointers in GPU for each bindings
     stream: pycuda.driver.Stream
         used for memory transfers between CPU-GPU
+
+    Notes
+    -----
+    If a binding is dynamic, create a :class:`DynamicHostDeviceMem` with :attr:`host` = :attr:`shape` = None
+    (new host will set this properties)
+
     """
     inputs = []
     outputs = []
-    bindings = []
+    has_dynamic_axes = False
     if stream is None and not sync_mode:
         stream = cuda.Stream()
     for binding in context.engine:
         binding_idx = context.engine.get_binding_index(binding)
         shape = context.get_binding_shape(binding_idx)
-        size = trt.volume(shape) * context.engine.max_batch_size
         dtype = trt.nptype(context.engine.get_binding_dtype(binding))
-        # Allocate host and device buffers
-        host_mem = cuda.pagelocked_empty(size, dtype)
-        device_mem = cuda.mem_alloc(host_mem.nbytes)
-        # Append the device buffer to device bindings.
-        bindings.append(int(device_mem))
+        if is_dynamic(shape):
+            # Not allocate buffers because is a dynamic binding
+            host_mem = device_mem = None
+            has_dynamic_axes = True
+            mem_obj = DynamicHostDeviceMem(host_mem, device_mem, shape, dtype, binding)
+        else:
+            size = trt.volume(shape) * context.engine.max_batch_size
+            # Allocate host and device buffers
+            host_mem = cuda.pagelocked_empty(size, dtype)
+            device_mem = cuda.mem_alloc(host_mem.nbytes)
+            mem_obj = HostDeviceMem(host_mem, device_mem, shape, dtype, binding)
         # Append to the appropriate list.
         if context.engine.binding_is_input(binding):
-            inputs.append(HostDeviceMem(host_mem, device_mem, shape, dtype, binding))
+            inputs.append(mem_obj)
         else:
-            outputs.append(HostDeviceMem(host_mem, device_mem, shape, dtype, binding))
-    return inputs, outputs, bindings, stream
+            outputs.append(mem_obj)
+    return inputs, outputs, stream, has_dynamic_axes
+
+
+def allocate_dynamic_mem(context, dict_inputs, dict_outputs):
+    """Set all input shapes in context to convert a dynamic context in static (output fix shapes).
+    Then, allocate output shapes
+
+    Parameters
+    ----------
+    context : trt.IExecutionContext
+    dict_inputs : Dict[str, HostDeviceMem]
+    dict_outputs : Dict[str, HostDeviceMem]
+    """
+    assert all(
+        mem_obj.device is not None and mem_obj.host is not None and not is_dynamic(mem_obj.shape)
+        for mem_obj in dict_inputs.values()
+    ), "When there are dynamic axes, all inputs shape must be set (model[i].host = array for all inputs)"
+
+    # Set input shape in context to update output shapes
+    for iname, mem_obj in dict_inputs.items():
+        idx = context.engine.get_binding_index(iname)
+        assert context.set_binding_shape(idx, mem_obj.shape), f"Impossible to set shape {mem_obj.shape} into {iname}"
+
+    # Create empty tensors to allocate output buffers
+    for oname, mem_obj in dict_outputs.items():
+        idx = context.engine.get_binding_index(oname)
+        shape = context.get_binding_shape(idx)  # Shape updated with inputs.set_binding_shape
+        if isinstance(mem_obj, DynamicHostDeviceMem):  # Buffer allocate
+            mem_obj.allocate_mem(shape)
+    return True
+
+
+def get_bindings(context, dict_inputs, dict_outputs):
+    """Get input/output pointers and add them into a list
+
+    Parameters
+    ----------
+    context : trt.IExecutionContext
+    dict_inputs : Dict[str, HostDeviceMem]
+    dict_outputs : Dict[str, HostDeviceMem]
+
+    Returns
+    -------
+    list
+        List of input/output pointers
+    """
+    bindings = [None] * (len(dict_inputs) + len(dict_outputs))
+
+    # Get bindings for inputs
+    for name, mem_obj in dict_inputs.items():
+        idx = context.engine.get_binding_index(name)
+        bindings[idx] = int(mem_obj.device) if mem_obj.device is not None else None
+
+    # Get bindings for outputs
+    for name, mem_obj in dict_outputs.items():
+        idx = context.engine.get_binding_index(name)
+        bindings[idx] = int(mem_obj.device) if mem_obj.device is not None else None
+    return bindings
 
 
 def execute_async(context, bindings, inputs, outputs, stream):

--- a/alonet/transformers/position_encoding.py
+++ b/alonet/transformers/position_encoding.py
@@ -2,11 +2,8 @@
 Various positional encodings for the transformer.
 """
 import math
-from numpy import dtype
 import torch
 from torch import nn
-
-import aloscene
 
 
 class PositionEmbeddingSine(nn.Module):
@@ -57,8 +54,8 @@ class PositionEmbeddingSine(nn.Module):
                 y_embed = y_embed - 0.5
                 x_embed = x_embed - 0.5
             eps = 1e-6
-            y_embed = y_embed / (y_embed[:, [-1], :] + eps) * self.scale
-            x_embed = x_embed / (x_embed[:, :, [-1]] + eps) * self.scale
+            y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
+            x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
 
         dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=ft_maps.device)
         dim_t = self.temperature ** (2 * torch.div(dim_t, 2, rounding_mode="floor") / self.num_pos_feats)
@@ -85,7 +82,8 @@ def build_position_encoding():
         # TODO find a better way of exposing other arguments
         position_embedding = PositionEmbeddingSine(N_steps, normalize=True)
     elif position_embedding in ("v3", "learned"):
-        position_embedding = PositionEmbeddingLearned(N_steps)
+        raise ValueError(f"not supported {position_embedding}")
+        # position_embedding = PositionEmbeddingLearned(N_steps)
     else:
         raise ValueError(f"not supported {position_embedding}")
 


### PR DESCRIPTION
Export **`PanopticHead` in `TensorRT `,** in one/two engine(s) with dynamic axes.

**New features:**
 * Update `detr_panoptic()`  forward to enable exportation (avoid not ops. implementation on tensorRT 8.2.0.6)
 * Implement `PanopticTRTExporter` class: Base exporter for Panoptic-based modules. According its configuration, it will export full model (detr + panoptic) or just panoptic head. The last is usefull to optimize forward step, where user would filter boxes before to pass through panoptic head module.

**Updates:**
 * Introduce of `dynamic axes`:  Proposal for the inclusion of `dynamic_axes` in `torch.onnx.export` procedure, as well as on `TRTEngineBuilder`. Inclusion of the optimization profile is required to generate the engine. 
 * Develop of `DynamicHostDeviceMem`, as memory object to allocate dynamic buffer at each forward step.

**Notes:**
* One tested-case of dynamic-axes was implemented in `alonet/detr_panoptic/trt_exporter.py`. Use this script to understand the way of use the news features.
* Deformable architecture was modified to be used by `PanopticHead`. However, deformable + Panoptic has not been tested yet.