### PR TITLE
Fix CameraIntrinsic last diag element

### DIFF
--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -74,6 +74,7 @@ class CameraIntrinsic(AugmentedTensor):
             x[0][2] = principal_point[1]
             x[1][2] = principal_point[0]
             x[2][2] = 1
+            x[3][3] = 1
 
         tensor = super().__new__(cls, x, *args, names=names, **kwargs)
         return tensor


### PR DESCRIPTION
Bugfix in `aloscene.camera_calib.CameraIntrinsic`
The last element of the diagonal of the `CameraIntrinsic` was 0 but it should be 1. This is fixed in this PR.