### PR TITLE
Panoptic2trt fix

### DIFF
--- a/alonet/deformable_detr/deformable_detr.py
+++ b/alonet/deformable_detr/deformable_detr.py
@@ -416,11 +416,8 @@ class DeformableDETR(nn.Module):
         Tuple
             (torch.Tensor, torch.Tensor) being the predicted labels and scores
         """
-        activation_fn = activation_fn or self.activation_fn
         assert (m_outputs) is not None
-        if "activation_fn" not in m_outputs:
-            raise Exception("'activation_fn' must be declared in forward output.")
-        activation_fn = m_outputs["activation_fn"]
+        activation_fn = m_outputs.get("activation_fn") or activation_fn or self.activation_fn
         if activation_fn == "softmax":
             outs_probs = F.softmax(m_outputs["pred_logits"], -1)
         else:
@@ -502,10 +499,7 @@ class DeformableDETR(nn.Module):
             Boxes filtered and predicted by forward outputs
         """
         outs_logits, outs_boxes = forward_out["pred_logits"], forward_out["pred_boxes"]
-
-        if "activation_fn" not in forward_out:
-            raise Exception("'activation_fn' must be declared in forward output.")
-        activation_fn = forward_out["activation_fn"]
+        activation_fn = forward_out.get("activation_fn") or self.activation_fn
 
         if activation_fn == "softmax":
             outs_probs = F.softmax(outs_logits, -1)

--- a/alonet/detr_panoptic/detr_panoptic.py
+++ b/alonet/detr_panoptic/detr_panoptic.py
@@ -290,7 +290,8 @@ class PanopticHead(nn.Module):
             # One shot encoding, to keep the high score class
             null_values = (~masks.bool()).all(dim=0, keepdim=True)  # Pixels without a score > maskth
             onehot_masks = torch.zeros_like(masks)
-            onehot_masks.scatter_(0, masks.argmax(dim=0, keepdim=True), 1)
+            if onehot_masks.numel():
+                onehot_masks.scatter_(0, masks.argmax(dim=0, keepdim=True), 1)
             masks = onehot_masks.type(torch.long) * (~null_values)  # One-hot encoding with threshold
 
             # Boxes/masks alignment


### PR DESCRIPTION
Fix bug in `activation_fn`, when `deformable_detr` is used as based model on `PanopticHead`.