### PR TITLE
Deformable panoptic

### DIFF
--- a/alonet/__init__.py
+++ b/alonet/__init__.py
@@ -9,5 +9,6 @@ from . import deformable_detr
 from . import callbacks
 
 from . import detr_panoptic
+from . import deformable_detr_panoptic
 
 from . import torch2trt

--- a/alonet/deformable_detr_panoptic/README.md
+++ b/alonet/deformable_detr_panoptic/README.md
@@ -12,6 +12,7 @@ model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(weights="defor
 model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(
     with_box_refine=True,
     weights="deformable-detr-r50-refinement-panoptic",
+    activation_fn="softmax,
 ).eval()
 
 # Open and normalized frame

--- a/alonet/deformable_detr_panoptic/README.md
+++ b/alonet/deformable_detr_panoptic/README.md
@@ -1,0 +1,76 @@
+# Deformable Detr Panoptic
+
+Here is a simple example to get started with **PanopticHead** and aloception. To learn more about PanopticHead, you can checkout the <a href="https://visual-behavior.github.io/aloception/tutorials/training_panoptic.html">Detr Tutorials</a> or the scripts described bellow.
+
+```python
+# Load model : Panoptic Head needs to load a module based on DETR architecture
+base_model = alonet.deformable_detr.DeformableDetrR50(num_classes=250)
+model = alonet.detr_panoptic.PanopticHead(DETR_module=base_model, weights="deformable-detr-r50-panoptic").eval()
+
+# Or simply, you can use one of the predefined model
+model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(weights="deformable-detr-r50-panoptic").eval()
+model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(
+    with_box_refine=True,
+    weights="deformable-detr-r50-refinement-panoptic",
+).eval()
+
+# Open and normalized frame
+frame = aloscene.Frame("/path/to/image.jpg").norm_resnet()
+
+# Run inference
+pred_boxes, pred_masks = model.inference(model([frame]))
+
+# Add and display the boxes/masks predicted
+frame.append_boxes2d(pred_boxes[0], "pred_boxes")
+frame.append_segmentation(pred_masks[0], "pred_masks")
+frame.get_view().render()
+```
+
+### Running inference with DeformableDetrR50 + PanopticHead
+
+```
+python alonet/deformable_detr_panoptic/deformable_detr_r50_panoptic.py /path/to/image.jpg
+```
+
+### Training Panoptic Deformable Detr from scratch
+```
+python alonet/deformable_detr_panoptic/train_on_coco.py
+```
+
+### Running evaluation of detr-r50-panoptic
+
+```
+python alonet/deformable_detr_panoptic/eval_on_coco.py --weights deformable-detr-r50-refinement-panoptic --model_name deformable-detr-r50-refinement-panoptic --activation_fn softmax [--ap_limit n]
+```
+
+```
+             |  all  |  .50  |  .55  |  .60  |  .65  |  .70  |  .75  |  .80  |  .85  |  .90  |  .95  |
+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
+ box         | 30.53 | 43.76 | 42.15 | 40.41 | 38.44 | 35.54 | 32.35 | 28.29 | 22.94 | 15.67 |  5.78 |
+ mask        | 19.56 | 32.18 | 30.25 | 28.16 | 26.07 | 23.56 | 20.39 | 16.59 | 11.39 |  5.79 |  1.25 |
+ precision   | 30.79 | 40.74 | 39.63 | 38.44 | 37.08 | 34.77 | 32.51 | 29.51 | 25.61 | 19.63 |  9.95 |
+ recall      | 42.08 | 55.56 | 54.11 | 52.41 | 50.53 | 47.74 | 44.62 | 40.52 | 34.99 | 26.69 | 13.66 |
+ box_ct      | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 |
+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
+
+-------+-------+-------+-------+-------+-------+
+                       |  PQst |  SQst |  RQst |
+-------+-------+-------+-------+-------+-------+
+-------+-------+-------+-------+-------+-------+
+ total = 53            | 0.242 | 0.712 | 0.294 |
+-------+-------+-------+-------+-------+-------+
+
+-------+-------+-------+-------+-------+-------+
+                       |  PQth |  SQth |  RQth |
+-------+-------+-------+-------+-------+-------+
+-------+-------+-------+-------+-------+-------+
+ total = 80            | 0.443 | 0.790 | 0.546 |
+-------+-------+-------+-------+-------+-------+
+
+-------+-------+-------+-------+-------+-------+
+                       |    PQ |    SQ |    RQ |
+-------+-------+-------+-------+-------+-------+
+-------+-------+-------+-------+-------+-------+
+ total = 133           | 0.363 | 0.759 | 0.446 |
+-------+-------+-------+-------+-------+-------+
+```

--- a/alonet/deformable_detr_panoptic/__init__.py
+++ b/alonet/deformable_detr_panoptic/__init__.py
@@ -1,0 +1,4 @@
+from .deformable_detr_r50_panoptic import DeformableDetrR50Panoptic
+from .deformable_detr_r50_panoptic_finetune import DeformableDetrR50PanopticFinetune
+from .criterion import DeformablePanopticCriterion
+from .train import LitPanopticDeformableDetr

--- a/alonet/deformable_detr_panoptic/callbacks.py
+++ b/alonet/deformable_detr_panoptic/callbacks.py
@@ -1,0 +1,2 @@
+"""Callbacks for Deformable DETR Panoptic training is the same as DETR Panoptic training
+"""

--- a/alonet/deformable_detr_panoptic/callbacks.py
+++ b/alonet/deformable_detr_panoptic/callbacks.py
@@ -1,2 +1,2 @@
-"""Callbacks for Deformable DETR Panoptic training is the same as DETR Panoptic training
+"""Callbacks for Deformable DETR Panoptic training are the same as DETR Panoptic training
 """

--- a/alonet/deformable_detr_panoptic/criterion.py
+++ b/alonet/deformable_detr_panoptic/criterion.py
@@ -1,0 +1,41 @@
+"""This class computes the loss for
+:mod:`DEFORMABLE DETR PANOPTIC <alonet.deformable_detr_panoptic.deformable_detr_panoptic>`.
+The process happens in two steps:
+
+1) We compute hungarian assignment between ground truth boxes and the outputs of the model
+2) We supervise each pair of matched ground-truth / prediction (supervise class, boxes and masks).
+"""
+
+from alonet.detr_panoptic.criterion import PanopticCriterion
+from alonet.deformable_detr import DeformableCriterion
+
+
+class DeformablePanopticCriterion(PanopticCriterion, DeformableCriterion):
+    """Create the criterion.
+
+    Parameters
+    ----------
+    num_classes: int
+        number of object categories, omitting the special no-object category
+    matcher: nn.Module
+        module able to compute a matching between targets and proposed boxes
+    loss_label_weight : float
+        Label class weight, to use in CE or sigmoid focal (default) loss (depends of network configuration)
+    loss_boxes_weight: float
+        Boxes loss l1 weight
+    loss_giou_weight: float
+        Boxes loss GIOU
+    loss_dice_weight: float
+        DICE/F-1 loss weight use in masks_loss
+    loss_focal_weight: float
+        Focal loss weight use in masks_loss
+    eos_coef: float
+        relative classification weight applied to the no-object category
+    focal_alpha : float, optional
+        This parameter is used only when the model use sigmoid activation function.
+        Weighting factor in range (0,1) to balance positive vs negative examples. -1 for no weighting, by default 0.25
+    aux_loss_stage:
+        Number of auxialiry stage
+    losses: list
+        list of all the losses to be applied. See get_loss for list of available losses.
+    """

--- a/alonet/deformable_detr_panoptic/deformable_detr_r50_panoptic.py
+++ b/alonet/deformable_detr_panoptic/deformable_detr_r50_panoptic.py
@@ -1,0 +1,111 @@
+"""Module to create a :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` model, using
+:mod:`DeformableDetrR50 <alonet.deformable_detr.deformable_detr_r50>` as detection architecture.
+"""
+
+from argparse import Namespace
+
+from alonet.common import load_weights
+from alonet.detr_panoptic import PanopticHead
+from alonet.deformable_detr import DeformableDetrR50, DeformableDetrR50Refinement
+
+
+class DeformableDetrR50Panoptic(PanopticHead):
+    """:mod:`DeformableDetrR50 <alonet.detr_deformable.deformable_detr_r50>` +
+    :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>`
+
+    Parameters
+    ----------
+    num_classes : int, optional
+        Number of classes in the :attr:`class_embed` output layer, by default 250
+    activation_fn : str, optional
+        Activation function for classification head. Either ``sigmoid`` or ``softmax``, by default "sigmoid".
+    with_box_refine : bool, optional
+        Use iterative box refinement, see paper for more details, by default False
+    deformable_weights : str, optional
+        Load weights to :mod:`DeformableDetrR50 <alonet.detr_deformable.deformable_detr_r50>`, by default None
+    weights : str, optional
+        Load weights from path or model_name, by default None
+    strict_load_weights : bool
+        Load the weights (if any given) with strict = ``True`` (by default)
+    **kwargs
+        Initial parameters of :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` module
+
+    Raises
+    ------
+    ValueError
+        :attr:`weights` must be a '.pth' or '.ckpt' file
+    """
+
+    def __init__(
+        self,
+        num_classes: int = 250,
+        activation_fn: str = "sigmoid",
+        with_box_refine: bool = False,
+        return_intermediate_dec: bool = True,
+        deformable_weights: str = None,
+        weights: str = None,
+        strict_load_weights: bool = True,
+        *args: Namespace,
+        **kwargs: dict,
+    ):
+        """Init method"""
+        base_model = DeformableDetrR50Refinement if with_box_refine else DeformableDetrR50
+        base_model = base_model(
+            num_classes=num_classes,
+            weights=deformable_weights,
+            activation_fn=activation_fn,
+            return_intermediate_dec=return_intermediate_dec,
+        )
+        super().__init__(*args, DETR_module=base_model, weights=None, **kwargs)
+
+        # Load weights
+        list_weights = ["deformable-detr-r50-panoptic", "deformable-detr-r50-refinement-panoptic"]
+        if weights is not None:
+            if ".pth" in weights or ".ckpt" in weights or weights in list_weights:
+                load_weights(self, weights, self.device, strict_load_weights=strict_load_weights)
+            else:
+                raise ValueError(f"Unknown weights: '{weights}'")
+
+
+def main(image_path):
+    import torch
+    import time
+    import aloscene
+
+    device = torch.device("cuda")
+
+    # Load model
+    model = DeformableDetrR50Panoptic(weights="deformable-detr-r50-panoptic")
+    model.to(device).eval()
+
+    # Open and prepare a batch for the model
+    frame = aloscene.Frame(image_path).norm_resnet()
+    frames = aloscene.Frame.batch_list([frame])
+    frames = frames.to(device)
+
+    # GPU warm up
+    [model(frames) for _ in range(3)]
+
+    tic = time.time()
+    with torch.no_grad():
+        [model(frames) for _ in range(20)]
+    toc = time.time()
+    print(f"{(toc - tic)/20*1000} ms")
+
+    # Predict boxes/masks
+    m_outputs = model(frames)  # Pred of size (B, NQ, H//4, W//4)
+    pred_boxes, pred_masks = model.inference(m_outputs, frame_size=frames.HW, threshold=0.85)
+
+    # Add and display the boxes/masks predicted
+    frame.append_boxes2d(pred_boxes[0], "pred_boxes")
+    frame.append_segmentation(pred_masks[0], "pred_masks")
+    frame.get_view().render()
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser(description="Detr R50 Panoptic inference on image")
+    parser.add_argument("image_path", type=str, help="Path to the image for inference")
+    args = parser.parse_args()
+    main(args.image_path)

--- a/alonet/deformable_detr_panoptic/deformable_detr_r50_panoptic_finetune.py
+++ b/alonet/deformable_detr_panoptic/deformable_detr_r50_panoptic_finetune.py
@@ -1,0 +1,84 @@
+"""Module to create a custom :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` model using
+:mod:`DeformableDetrR50 <alonet.deformable_detr.deformable_detr_r50>` as based model, which allows to upload a
+decided pretrained weights and change the number of outputs in :attr:`class_embed` layer, in order to train custom
+classes.
+"""
+
+import torch
+import math
+from argparse import Namespace
+
+from alonet.deformable_detr_panoptic import DeformableDetrR50Panoptic
+from alonet.common.weights import load_weights
+
+
+class DeformableDetrR50PanopticFinetune(DeformableDetrR50Panoptic):
+    """Pre made helpfull class to finetune the :mod:`DeformableDetrR50 <alonet.deformable_detr.deformable_detr_r50>`
+    and use a pretrained :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>`.
+
+    Parameters
+    ----------
+    num_classes : int
+        Number of classes in the :attr:`class_embed` output layer
+    base_weights : str, optional
+        Load weights to the original
+        :mod:`DeformableDetrR50Panoptic <alonet.deformable_detr_panoptic.deformable_detr_r50_panoptic>`,
+        by default "deformable-detr-r50-panoptic"
+    weights : str, optional
+        Weights for finetune model, by default None
+    use_bn_layers : bool, optional
+        Replace group norm layer in :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` by batch norm layer,
+        by default False
+    **kwargs
+        Initial parameters of
+        :mod:`DeformableDetrR50panoptic <alonet.deformable_detr_panoptic.deformable_detr_r50_panoptic>` module
+
+    Raises
+    ------
+    ValueError
+        :attr:`weights` must be a '.pth' or '.ckpt' file
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        base_weights: str = "deformable-detr-r50-panoptic",
+        weights: str = None,
+        use_bn_layers: bool = False,
+        *args: Namespace,
+        **kwargs: dict,
+    ):
+        """Init method"""
+        super().__init__(*args, weights=base_weights, **kwargs)
+
+        self.detr.background_class = num_classes if self.detr.activation_fn == "softmax" else None
+        num_classes += 1 if self.detr.activation_fn == "softmax" else 0  # Add bg class
+
+        # Replace the class_embed layer a new layer once the deformable-detr-r50 weight are loaded
+        self.detr.class_embed = torch.nn.Linear(self.detr.transformer.d_model, num_classes)
+        prior_prob = 0.01
+        bias_value = -math.log((1 - prior_prob) / prior_prob)
+        self.detr.class_embed.bias.data = torch.ones(num_classes) * bias_value
+        self.detr.class_embed = self.detr.class_embed.to(self.device)
+        num_pred = self.detr.transformer.decoder.num_layers
+        self.detr.class_embed = torch.nn.ModuleList([self.detr.class_embed for _ in range(num_pred)])
+
+        # Replace group by batch norm layers
+        if use_bn_layers:
+            for ignl in range(1, 6):
+                gname = "gn" + str(ignl)
+                glayer = getattr(self.mask_head, gname)
+                setattr(self.mask_head, gname, torch.nn.BatchNorm2d(glayer.num_channels))
+
+        # Load weights procedure
+        if weights is not None:
+            if ".pth" in weights or ".ckpt" in weights:
+                load_weights(self, weights, self.device)
+            else:
+                raise ValueError(f"Unknown weights: '{weights}'")
+
+
+if __name__ == "__main__":
+    # Setup a new Detr Model with 2 class and the background class equal to 0.
+    # Additionally, we're gonna load the pretrained deformable-detr-r50 weights.
+    panoptic_finetune = DeformableDetrR50PanopticFinetune(num_classes=2)

--- a/alonet/deformable_detr_panoptic/eval_on_coco.py
+++ b/alonet/deformable_detr_panoptic/eval_on_coco.py
@@ -1,0 +1,62 @@
+from argparse import ArgumentParser
+from tqdm import tqdm
+import torch
+
+from alonet.common import add_argparse_args
+from alonet.detr import CocoPanoptic2Detr
+from alonet.deformable_detr_panoptic import LitPanopticDeformableDetr
+from alonet.metrics import PQMetrics, ApMetrics
+
+
+from aloscene import Frame
+
+
+def main(args):
+    """ Main
+    """
+    device = torch.device("cuda")
+
+    # Init the DetrPanoptic model with the dataset
+    coco_loader = CocoPanoptic2Detr(args, batch_size=1)
+    lit_panoptic = LitPanopticDeformableDetr(args=args)
+    lit_panoptic.model = lit_panoptic.model.eval().to(device)
+
+    # Define the metric used in evaluation process
+    pq_metric = PQMetrics()
+    ap_metric = ApMetrics()
+
+    # Make all predictions to use metric defined
+    tbar = tqdm(total=len(coco_loader.val_dataloader()) if args.ap_limit is None else args.ap_limit)
+    for it, data in enumerate(coco_loader.val_dataloader()):
+        frame = Frame.batch_list(data).to(device)
+
+        pred_boxes, pred_masks = lit_panoptic.inference(lit_panoptic(frame, threshold=0.85))
+        pred_boxes, pred_masks = pred_boxes[0], pred_masks[0]
+        gt_boxes = frame.boxes2d[0]  # Get gt boxes as BoundingBoxes2D.
+        gt_masks = frame.segmentation[0]  # Get gt masks as Mask
+
+        # Add samples to evaluate metrics
+        pq_metric.add_sample(p_mask=pred_masks, t_mask=gt_masks)
+        gt_boxes.labels, gt_masks.labels = gt_boxes.labels["category"], gt_masks.labels["category"]
+        ap_metric.add_sample(p_bbox=pred_boxes, p_mask=pred_masks, t_bbox=gt_boxes, t_mask=gt_masks)
+
+        tbar.update()
+        if args.ap_limit is not None and it >= args.ap_limit:
+            break
+
+    # Show the results
+    print("Total eval batch:", it)
+    ap_metric.calc_map(print_result=True)
+    pq_metric.calc_map(print_result=True)
+
+
+if __name__ == "__main__":
+    # Build parser
+    parser = ArgumentParser(conflict_handler="resolve")
+    parser = add_argparse_args(parser)  # Common alonet parser
+    parser = CocoPanoptic2Detr.add_argparse_args(parser)  # Coco panoptic parser
+    parser = LitPanopticDeformableDetr.add_argparse_args(parser)  # LitPanopticDetr training parser
+    parser.add_argument(
+        "--ap_limit", type=int, default=None, help="Limit AP computation at the given number of sample"
+    )
+    main(parser.parse_args())

--- a/alonet/deformable_detr_panoptic/train.py
+++ b/alonet/deformable_detr_panoptic/train.py
@@ -56,13 +56,6 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
             + ", by default %(default)s",
         )
         parser.add_argument(
-            "--activation_fn",
-            type=str,
-            default="sigmoid",
-            choices=["sigmoid", "softmax"],
-            help="Activation function in class embed layer, by default %(default)s",
-        )
-        parser.add_argument(
             "--freeze_detr", action="store_true", help="Freeze DETR weights in training, by default %(default)s"
         )
         return parent_parser

--- a/alonet/deformable_detr_panoptic/train.py
+++ b/alonet/deformable_detr_panoptic/train.py
@@ -23,7 +23,7 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
     accumulate_grad_batches : int, optional
         Accumulates grads every k batches or as set up in the dict, by default 4
     model_name : str, optional
-        Name use to define the model, by default "deformable-detr-r50-panoptic"
+        Name use to define the model, by default ``deformable-detr-r50-panoptic``
     model : torch.nn, optional
         Custom model to train
 
@@ -70,7 +70,7 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
         num_classes : int, optional
             Number of classes in embed layer, by default 250
         aux_loss : bool, optional
-            Return auxiliar outputs in forward output, by default True
+            Return auxiliar outputs in forward output, by default ``True``
         weights : str, optional
             Path or id to load weights, by default None
         activation_fn : str, optional
@@ -84,7 +84,7 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
         Raises
         ------
         Exception
-            Only :attr:`deformable-detr-r50-panoptic` and :attr:`deformable-detr-r50-refinement-panoptic` are accepted.
+            Only ``deformable-detr-r50-panoptic`` and ``deformable-detr-r50-refinement-panoptic`` are accepted.
         """
         if self.model_name == "deformable-detr-r50-panoptic":
             model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(
@@ -146,14 +146,14 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
             Weighting factor in range (0,1) to balance positive vs negative examples. -1 for no weighting,
             by default 0.25
         losses : list, optional
-            List of losses to take into account in total loss, by default ["labels", "boxes", "masks"].
-            Possible values: ["labels", "boxes", "masks"] (use the latest in segmentation tasks)
+            List of losses to take into account in total loss, by default [``labels``, ``boxes``, ``masks``] (uses all
+            the possible values).
         aux_loss_stage : int, optional
             Size of stages from :attr:`aux_outputs` key in forward ouputs, by default 6
 
         Returns
         -------
-        :mod:`DetrCriterion <alonet.detr.criterion>`
+        :mod:`DeformablePanopticCriterion <alonet.deformable_detr_panoptic.criterion>`
             Criterion use to train the model
         """
         return alonet.deformable_detr_panoptic.DeformablePanopticCriterion(
@@ -170,6 +170,22 @@ class LitPanopticDeformableDetr(LitPanopticDetr):
         )
 
     def build_matcher(self, cost_class: float = 1, cost_boxes: float = 5, cost_giou: float = 2):
+        """Build matcher to match between predictions and targets
+
+        Parameters
+        ----------
+        cost_class : int, optional
+            Weight of the classification error in the matching cost, by default 1
+        cost_boxes : int, optional
+            Weight of the L1 error of the bounding box coordinates in the matching cost, by default 5
+        cost_giou : int, optional
+            Weight of the giou loss of the bounding box in the matching cost, by default 2
+
+        Returns
+        -------
+        :mod:`DeformableDetrHungarianMatcher <alonet.deformable_detr.matcher>`
+            Hungarian Matcher, as a Pytorch model
+        """
         return alonet.deformable_detr.DeformableDetrHungarianMatcher(
             cost_class=cost_class, cost_boxes=cost_boxes, cost_giou=cost_giou
         )

--- a/alonet/deformable_detr_panoptic/train.py
+++ b/alonet/deformable_detr_panoptic/train.py
@@ -1,0 +1,198 @@
+"""`Pytorch Lightning Module <https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html>`_ to
+train models based on :mod:`~alonet.deformable_detr_panoptic.deformable_detr_panoptic` module
+"""
+
+import alonet
+import torch
+from argparse import ArgumentParser, _ArgumentGroup, Namespace
+
+from alonet.detr_panoptic import LitPanopticDetr
+from aloscene import Frame
+
+
+class LitPanopticDeformableDetr(LitPanopticDetr):
+    """
+    Parameters
+    ----------
+    args : Namespace, optional
+        Attributes stored in specific Namespace, by default None
+    weights : str, optional
+        Weights name to load, by default None
+    gradient_clip_val : float, optional
+        pytorch_lightning.trainer.trainer parameter. 0 means dont clip, by default 0.1
+    accumulate_grad_batches : int, optional
+        Accumulates grads every k batches or as set up in the dict, by default 4
+    model_name : str, optional
+        Name use to define the model, by default "deformable-detr-r50-panoptic"
+    model : torch.nn, optional
+        Custom model to train
+
+    Notes
+    -----
+    Arguments entered by the user (kwargs) will replace those stored in args attribute
+    """
+
+    @staticmethod
+    def add_argparse_args(parent_parser: ArgumentParser, parser: _ArgumentGroup = None):
+        parser = parent_parser.add_argument_group("LitPanopticDeformableDetr") if parser is None else parser
+        parser.add_argument(
+            "--weights", type=str, default=None, help="One of {deformable-detr-r50-panoptic}, by default %(default)s",
+        )
+        parser.add_argument(
+            "--gradient_clip_val", type=float, default=0.1, help="Gradient clipping norm, by default %(default)s"
+        )
+        parser.add_argument(
+            "--accumulate_grad_batches",
+            type=int,
+            default=4,
+            help="Number of gradient accumulation steps, by default %(default)s",
+        )
+        parser.add_argument("--track_grad_norm", type=int, default=-1, help="Tracks that p-norm, by default no track")
+        parser.add_argument(
+            "--model_name",
+            type=str,
+            default="deformable-detr-r50-panoptic",
+            help="Model name to use. One of {'deformable-detr-r50-panoptic','deformable-detr-r50-refinement-panoptic'}"
+            + ", by default %(default)s",
+        )
+        parser.add_argument(
+            "--activation_fn",
+            type=str,
+            default="sigmoid",
+            choices=["sigmoid", "softmax"],
+            help="Activation function in class embed layer, by default %(default)s",
+        )
+        parser.add_argument(
+            "--freeze_detr", action="store_true", help="Freeze DETR weights in training, by default %(default)s"
+        )
+        return parent_parser
+
+    def build_model(
+        self, num_classes: int = 250, aux_loss: bool = True, weights: str = None, activation_fn: str = "sigmoid"
+    ):
+        """Build the default model
+
+        Parameters
+        ----------
+        num_classes : int, optional
+            Number of classes in embed layer, by default 250
+        aux_loss : bool, optional
+            Return auxiliar outputs in forward output, by default True
+        weights : str, optional
+            Path or id to load weights, by default None
+        activation_fn : str, optional
+            Activation function for classification head. Either ``sigmoid`` or ``softmax``. By default sigmoid.
+
+        Returns
+        -------
+        :mod:`~alonet.deformable_detr_panoptic.deformable_detr_panoptic`
+            Pytorch model
+
+        Raises
+        ------
+        Exception
+            Only :attr:`deformable-detr-r50-panoptic` and :attr:`deformable-detr-r50-refinement-panoptic` are accepted.
+        """
+        if self.model_name == "deformable-detr-r50-panoptic":
+            model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(
+                num_classes=num_classes,
+                aux_loss=aux_loss,
+                activation_fn=activation_fn,
+                return_detr_outputs=True,
+                with_box_refine=False,
+                weights=weights or self.weights,
+                freeze_detr=self.freeze_detr,
+            )
+        elif self.model_name == "deformable-detr-r50-refinement-panoptic":
+            model = alonet.deformable_detr_panoptic.DeformableDetrR50Panoptic(
+                num_classes=num_classes,
+                aux_loss=aux_loss,
+                activation_fn=activation_fn,
+                return_detr_outputs=True,
+                with_box_refine=True,
+                weights=weights or self.weights,
+                freeze_detr=self.freeze_detr,
+            )
+        else:
+            raise Exception(f"Unsupported base model {self.model_name}")
+        return model
+
+    def build_criterion(
+        self,
+        matcher: torch.nn = None,
+        loss_dice_weight: float = 2,
+        loss_focal_weight: float = 2,
+        loss_label_weight: float = 1,
+        loss_boxes_weight: float = 5,
+        loss_giou_weight: float = 2,
+        eos_coef: float = 0.1,
+        focal_alpha: float = 0.25,
+        losses: list = ["masks", "boxes", "labels"],
+        aux_loss_stage: int = 6,
+    ):
+        """Build the default criterion
+
+        Parameters
+        ----------
+        matcher : torch.nn, optional
+            One specfic matcher to use in criterion process, by default the output of :func:`build_matcher`
+        loss_label_weight : float, optional
+            Weight of cross entropy loss in total loss, by default 1
+        loss_boxes_weight : float, optional
+            Weight of boxes loss in total loss, by default 5
+        loss_giou_weight : float, optional
+            Weight of GIoU loss in total loss, by default 2
+        loss_dice_weight : float, optional
+            Weight of DICE/F-1 loss in total loss, by default 2
+        loss_focal_weight : float, optional
+            Weight of sigmoid focal loss in total loss, by default 2
+        eos_coef : float, optional
+            Background/End of the Sequence (EOS) coefficient, by default 0.1
+        focal_alpha : float, optional
+            This parameter is used only when the model use sigmoid activation function.
+            Weighting factor in range (0,1) to balance positive vs negative examples. -1 for no weighting,
+            by default 0.25
+        losses : list, optional
+            List of losses to take into account in total loss, by default ["labels", "boxes", "masks"].
+            Possible values: ["labels", "boxes", "masks"] (use the latest in segmentation tasks)
+        aux_loss_stage : int, optional
+            Size of stages from :attr:`aux_outputs` key in forward ouputs, by default 6
+
+        Returns
+        -------
+        :mod:`DetrCriterion <alonet.detr.criterion>`
+            Criterion use to train the model
+        """
+        return alonet.deformable_detr_panoptic.DeformablePanopticCriterion(
+            matcher=matcher or self.matcher,
+            loss_label_weight=loss_label_weight,
+            loss_boxes_weight=loss_boxes_weight,
+            loss_giou_weight=loss_giou_weight,
+            loss_dice_weight=loss_dice_weight,
+            loss_focal_weight=loss_focal_weight,
+            eos_coef=eos_coef,
+            focal_alpha=focal_alpha,
+            aux_loss_stage=aux_loss_stage,
+            losses=losses,
+        )
+
+    def build_matcher(self, cost_class: float = 1, cost_boxes: float = 5, cost_giou: float = 2):
+        return alonet.deformable_detr.DeformableDetrHungarianMatcher(
+            cost_class=cost_class, cost_boxes=cost_boxes, cost_giou=cost_giou
+        )
+
+    def run_train(
+        self,
+        data_loader: Frame,
+        args: Namespace,
+        project: str = "deformable-detr-panoptic",
+        expe_name: str = None,
+        callbacks: list = None,
+    ):
+        expe_name = expe_name or self.model_name
+        super().run_train(data_loader, args, project, expe_name, callbacks)
+
+
+if __name__ == "__main__":
+    args = LitPanopticDeformableDetr.add_argparse_args(ArgumentParser()).parse_args()  # Help provider
+    model = LitPanopticDeformableDetr(args)

--- a/alonet/deformable_detr_panoptic/train_on_coco.py
+++ b/alonet/deformable_detr_panoptic/train_on_coco.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+from alonet.deformable_detr_panoptic import LitPanopticDeformableDetr
+from alonet.detr import CocoPanoptic2Detr
+
+import alonet
+
+
+def get_arg_parser():
+    parser = ArgumentParser(conflict_handler="resolve")
+    parser = alonet.common.add_argparse_args(parser)  # Common alonet parser
+    parser = CocoPanoptic2Detr.add_argparse_args(parser)  # Coco detection parser
+    parser = LitPanopticDeformableDetr.add_argparse_args(parser)  # LitDetr training parser
+    # parser = pl.Trainer.add_argparse_args(parser) # Pytorch lightning Parser
+    return parser
+
+
+def main():
+    """Main"""
+    # Build parser
+    args = get_arg_parser().parse_args()  # Parse
+
+    # Init the Panoptic2Detr and LitPanoptic modules
+    coco_loader = CocoPanoptic2Detr(args=args)
+    lit_panoptic = LitPanopticDeformableDetr(args)
+
+    # Start training
+    lit_panoptic.run_train(data_loader=coco_loader, args=args, project="deformable-detr-panoptic", expe_name="coco")
+
+
+if __name__ == "__main__":
+    main()

--- a/alonet/deformable_detr_panoptic/trt_exporter.py
+++ b/alonet/deformable_detr_panoptic/trt_exporter.py
@@ -1,0 +1,145 @@
+"""Helper class for exporting PyTorch model to TensorRT engine
+"""
+
+import argparse
+import os
+import torch
+import onnx
+import onnx_graphsurgeon as gs
+
+from alonet.torch2trt.onnx_hack import rename_nodes_
+from alonet.torch2trt import BaseTRTExporter
+from aloscene import Frame
+
+
+class PanopticTRTExporter(BaseTRTExporter):
+    def __init__(self, *args, export_with_detr: bool = False, **kwargs):
+        # Get default inputs
+        input_names = kwargs.get("input_names", None)
+        if input_names is None:
+            if export_with_detr:
+                kwargs["input_names"] = ("img",)
+            else:
+                kwargs["input_names"] = (
+                    "dec_outputs",
+                    "enc_outputs",
+                    "bb_lvl0_src_outputs",
+                    "bb_lvl1_src_outputs",
+                    "bb_lvl2_src_outputs",
+                    "bb_lvl3_src_outputs",
+                    "bb_lvl3_mask_outputs",
+                )
+                kwargs["dynamic_axes"] = kwargs.get("dynamic_axes", None) or {"dec_outputs": {2: "num_queries"}}
+
+        super().__init__(*args, **kwargs)
+        self.custom_opset = None
+        self.export_with_detr = export_with_detr
+
+    def adapt_graph(self, graph: gs.Graph):
+        # return graph  # Not optimize
+        from onnxsim import simplify
+
+        # no need to modify graph
+        model = onnx.load(self.onnx_path)
+        check = False
+        if self.dynamic_axes is not None:
+            model_simp, check = simplify(
+                model,
+                dynamic_input_shape=True,  # Choose optimal values for simplify
+                input_shapes={key: val[1] for key, val in self.engine_builder.opt_profiles.items()},
+            )
+        else:
+            model_simp, check = simplify(model)
+
+        if check:
+            print("\n[INFO] Simplified ONNX model validated. Graph optimized...")
+            graph = gs.import_onnx(model_simp)
+            graph.toposort()
+            graph.cleanup()
+        else:
+            print("\n[INFO] ONNX model was not validated.")
+
+        if self.use_scope_names:  # Rename nodes to correct profiling
+            graph = rename_nodes_(graph, verbose=True)
+        return graph
+
+    def prepare_sample_inputs(self):
+        assert len(self.input_shapes) == 1, "Panoptic takes only 1 input"
+        shape = self.input_shapes[0]
+        x = torch.rand(shape, dtype=torch.float32)
+        x = Frame(x, names=["C", "H", "W"]).norm_resnet()
+        x = Frame.batch_list([x] * self.batch_size).to(self.device)
+        x = torch.cat((x.as_tensor(), x.mask.as_tensor()), dim=1)  # [b, 4, H, W]
+
+        if self.export_with_detr:  # Image as input = export detr + panoptic
+            tensor_input = (x,)
+        else:  # dict as input = export only panoptic
+            with torch.no_grad():
+                tensor_input = self.model.detr_forward(x)  # Get Detr outputs expected
+
+            tensor_input = {iname: tensor_input[iname].contiguous() for iname in self.input_names}
+        return tensor_input, {"is_export_onnx": None}
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Not implemented yet")
+    from alonet.common.weights import vb_fodler
+    from alonet.detr_panoptic import PanopticHead
+    from alonet.detr import DetrR50
+    from alonet.detr.trt_exporter import DetrTRTExporter
+
+    # test script
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--HW", type=int, nargs=2, default=[1280, 1920], help="Height and width of input image, by default %(default)s"
+    )
+    parser.add_argument("--cpu", action="store_true", help="Compile model in CPU, by default %(default)s")
+    parser.add_argument(
+        "--split_engines",
+        action="store_true",
+        help="Save DETR/Panoptic engines in different files, by default %(default)s",
+    )
+    BaseTRTExporter.add_argparse_args(parser)
+
+    args = parser.parse_args()
+    device = torch.device("cpu") if args.cpu else torch.device("cuda")
+    input_shape = [3] + list(args.HW)
+    pan_onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50-panoptic")
+    if args.split_engines:
+        pan_onnx_path = os.path.join(pan_onnx_path, "panoptic-head.onnx")
+    else:
+        pan_onnx_path = os.path.join(pan_onnx_path, "detr-r50-panoptic.onnx")
+    pan_onnx_path = args.onnx_path or pan_onnx_path
+
+    model = PanopticHead(
+        DETR_module=DetrR50(num_classes=250, background_class=None),
+        weights="detr-r50-panoptic",
+        tracing=True,
+        aux_loss=False,
+        return_pred_outputs=not args.split_engines,
+    )
+    model = model.eval().to(device)
+
+    if args.split_engines:
+        # 1. Export Detr engine
+        print("\n[INFO] Exporting DETR engine...")
+        args.onnx_path = os.path.join(os.path.split(pan_onnx_path)[0], "detr-r50.onnx")
+        exporter = DetrTRTExporter(
+            model=model.detr, input_shapes=(input_shape,), input_names=["img"], device=device, **vars(args)
+        )
+        exporter.export_engine()
+
+        print("\n\n[INFO] Exporting PanopticHead engine...")
+
+    # 2. Export PanopticHead engine
+    args.onnx_path = pan_onnx_path
+    profile = {"dec_outputs": [(6, 1, 1, 256), (6, 1, 10, 256), (6, 1, 100, 256)]} if args.split_engines else None
+    exporter = PanopticTRTExporter(
+        model=model,
+        input_shapes=(input_shape,),
+        export_with_detr=not args.split_engines,
+        device=device,
+        opt_profiles=profile,  # Example of profile for dynamic num of queries
+        **vars(args),
+    )
+    exporter.export_engine()

--- a/alonet/detr/detr_r50_finetune.py
+++ b/alonet/detr/detr_r50_finetune.py
@@ -58,4 +58,4 @@ class DetrR50Finetune(DetrR50):
 if __name__ == "__main__":
     # Setup a new Detr Model with 2 class and the background class equal to 0.
     # Additionally, we're gonna load the pretrained detr-r50 weights.
-    detr_r50_finetune = DetrR50Finetune(num_classes=2, weights="detr-r50")
+    detr_r50_finetune = DetrR50Finetune(num_classes=2, base_weights="detr-r50")

--- a/alonet/detr_panoptic/README.md
+++ b/alonet/detr_panoptic/README.md
@@ -1,12 +1,14 @@
 # Detr Panoptic
 
-Here is a simple example to get started with **PanopticHead** and aloception. To learn more about PanopticHead, you can checkout the <a href="https://visual-behavior.github.io/aloception/tutorials/training_panoptic.html">Detr Tutorials</a> or
-the scripts described bellow.
+Here is a simple example to get started with **PanopticHead** and aloception. To learn more about PanopticHead, you can checkout the <a href="https://visual-behavior.github.io/aloception/tutorials/training_panoptic.html">Detr Tutorials</a> or the scripts described bellow.
 
 ```python
 # Load model : Panoptic Head needs to load a module based on DETR architecture
-detr_model = alonet.detr.DetrR50(num_classes=250, background=250)
+detr_model = alonet.detr.DetrR50(num_classes=250)
 model = alonet.detr_panoptic.PanopticHead(DETR_module=detr_model, weights="detr-r50-panoptic").eval()
+
+# Or simply, you can use the predefined model
+model = alonet.detr_panoptic.DetrR50Panoptic(weights="detr-r50-panoptic").eval()
 
 # Open and normalized frame
 frame = aloscene.Frame("/path/to/image.jpg").norm_resnet()
@@ -23,7 +25,7 @@ frame.get_view().render()
 ### Running inference with DetrR50 + PanopticHead
 
 ```
-python alonet/detr_panoptic/detr_panoptic.py /path/to/image.jpg
+python alonet/detr_panoptic/detr_r50_panoptic.py /path/to/image.jpg
 ```
 
 ### Training Panoptic Detr from scratch
@@ -34,14 +36,18 @@ python alonet/detr_panoptic/train_on_coco.py
 ### Running evaluation of detr-r50-panoptic
 
 ```
-python alonet/detr_panoptic/eval_on_coco.py --weights detr-r50-panoptic --batch_size 1 [--ap_limit n]
+python alonet/detr_panoptic/eval_on_coco.py --weights detr-r50-panoptic [--ap_limit n]
 ```
 
 ```
-                 |  all  |  .50  |  .55  |  .60  |  .65  |  .70  |  .75  |  .80  |  .85  |  .90  |  .95  |
+     		 |  all  |  .50  |  .55  |  .60  |  .65  |  .70  |  .75  |  .80  |  .85  |  .90  |  .95  |
 -------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
- box             | 31.26 | 45.16 | 43.57 | 41.39 | 39.13 | 36.44 | 32.70 | 28.38 | 23.09 | 15.95 |  6.77 |
- mask            | 24.62 | 41.47 | 39.11 | 36.43 | 33.21 | 29.41 | 24.90 | 19.87 | 13.68 |  6.77 |  1.38 |
+ box		 | 33.85 | 49.88 | 47.83 | 45.33 | 42.58 | 39.36 | 35.12 | 30.25 | 24.41 | 16.71 |  7.03 |
+ mask		 | 24.64 | 41.50 | 39.13 | 36.44 | 33.24 | 29.44 | 24.91 | 19.85 | 13.70 |  6.77 |  1.38 |
+ precision	 | 31.75 | 43.25 | 41.90 | 40.31 | 38.43 | 36.21 | 33.20 | 29.70 | 25.30 | 19.04 | 10.14 |
+ recall		 | 44.18 | 60.96 | 58.92 | 56.52 | 53.70 | 50.39 | 46.07 | 41.02 | 34.66 | 25.85 | 13.69 |
+ box_ct		 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 | 56728.0 |
+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
 
 -------+-------+-------+-------+-------+-------+
                        |  PQst |  SQst |  RQst |

--- a/alonet/detr_panoptic/__init__.py
+++ b/alonet/detr_panoptic/__init__.py
@@ -1,6 +1,6 @@
 from .detr_panoptic import PanopticHead
+from .detr_r50_panoptic import DetrR50Panoptic
 from .detr_r50_panoptic_finetune import DetrR50PanopticFinetune
-from .criterion import DetrPanopticCriterion, DeformablePanopticCriterion
-from .callbacks import PanopticObjectDetectorCallback
-from .callbacks import PanopticApMetricsCallbacks
+from .criterion import DetrPanopticCriterion
+from .callbacks import PanopticObjectDetectorCallback, PanopticApMetricsCallbacks
 from .train import LitPanopticDetr

--- a/alonet/detr_panoptic/criterion.py
+++ b/alonet/detr_panoptic/criterion.py
@@ -10,8 +10,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from alonet.detr import DetrCriterion
-from alonet.deformable_detr import DeformableCriterion
-
 import aloscene
 
 
@@ -184,37 +182,6 @@ class DetrPanopticCriterion(PanopticCriterion, DetrCriterion):
         module able to compute a matching between targets and proposed boxes
     loss_ce_weight: float
         Cross entropy class weight
-    loss_boxes_weight: float
-        Boxes loss l1 weight
-    loss_giou_weight: float
-        Boxes loss GIOU
-    loss_dice_weight: float
-        DICE/F-1 loss weight use in masks_loss
-    loss_focal_weight: float
-        Focal loss weight use in masks_loss
-    eos_coef: float
-        relative classification weight applied to the no-object category
-    focal_alpha : float, optional
-        This parameter is used only when the model use sigmoid activation function.
-        Weighting factor in range (0,1) to balance positive vs negative examples. -1 for no weighting, by default 0.25
-    aux_loss_stage:
-        Number of auxialiry stage
-    losses: list
-        list of all the losses to be applied. See get_loss for list of available losses.
-    """
-
-
-class DeformablePanopticCriterion(PanopticCriterion, DeformableCriterion):
-    """Create the criterion.
-
-    Parameters
-    ----------
-    num_classes: int
-        number of object categories, omitting the special no-object category
-    matcher: nn.Module
-        module able to compute a matching between targets and proposed boxes
-    loss_label_weight : float
-        Label class weight, to use in CE or sigmoid focal (default) loss (depends of network configuration)
     loss_boxes_weight: float
         Boxes loss l1 weight
     loss_giou_weight: float

--- a/alonet/detr_panoptic/detr_panoptic.py
+++ b/alonet/detr_panoptic/detr_panoptic.py
@@ -122,8 +122,8 @@ class PanopticHead(nn.Module):
               each individual image (disregarding possible padding).
             - :attr:`enc_outputs` : Transformer encoder outputs.
             - :attr:`dec_outputs` : Transformer decoder outputs.
-            - :attr:`bb_outputs` : Backbone outputs, in `attr`:`bb_lvl{i}_src_outputs`,`attr`:`bb_lvl{i}_mask_outputs`
-              and `attr`:`bb_lvl{i}_pos_outputs` format, with {i} the backbone level.
+            - :attr:`bb_outputs` : Backbone outputs, in :attr:`bb_lvl{i}_src_outputs`, :attr:`bb_lvl{i}_mask_outputs`
+              and :attr:`bb_lvl{i}_pos_outputs` format, with **{i}** the backbone level.
 
         get_filter_fn : Callable
             Function that must return two parameters : the :attr:`dec_outputs` tensor filtered by a boolean mask per
@@ -141,7 +141,8 @@ class PanopticHead(nn.Module):
             - :attr:`pred_masks_info` : Parameters to use in inference procedure
             - :attr:`aux_outputs` : Optional, only returned when auxilary losses are activated. It is a list of
               dictionnaries containing the two above keys for each decoder layer.
-            - **:attr:`DETR_outputs`, such as :attr:`pred_logits` and :attr:`pred_boxes`.
+            - :attr:`pred_logits` and :attr:`pred_boxes`, Optional, if :attr:`return_pred_outputs` = ``True``
+            - **:attr:`DETR_forward_outputs`, Optional, if :attr:`return_detr_outputs` = ``True``
         """
         # DETR model forward to obtain box embeddings
         if self.tracing and isinstance(frames, dict):  # Expected export only panoptic Head (without detr)

--- a/alonet/detr_panoptic/detr_panoptic.py
+++ b/alonet/detr_panoptic/detr_panoptic.py
@@ -5,8 +5,6 @@ Panoptic module to use in object detection/segmentation tasks.
 """
 from typing import Callable, Dict, Union
 from collections import namedtuple
-import argparse
-import time
 
 import torch
 import torch.nn.functional as F
@@ -147,9 +145,7 @@ class PanopticHead(nn.Module):
         """
         # DETR model forward to obtain box embeddings
         if self.tracing and isinstance(frames, dict):  # Expected export only panoptic Head (without detr)
-            assert all([x in frames for x in ["dec_outputs", "enc_outputs", "bb_lvl3_mask_outputs"]])
-            assert all([x in frames for x in [f"bb_lvl{i}_src_outputs" for i in range(4)]])
-            detr_out = frames  # Expected encode/decode/backbone tensors in frames"
+            detr_out = frames
         else:
             detr_out = self.detr_forward(frames, **kwargs)
 
@@ -314,43 +310,3 @@ class PanopticHead(nn.Module):
             preds_masks.append(masks)
 
         return preds_boxes, preds_masks
-
-
-def main(image_path):
-    from alonet.detr import DetrR50Finetune
-
-    device = torch.device("cuda")
-
-    # Load model
-    model = PanopticHead(DetrR50Finetune(num_classes=250), weights="detr-r50-panoptic")
-    model.to(device).eval()
-
-    # Open and prepare a batch for the model
-    frame = aloscene.Frame(image_path).norm_resnet()
-    frames = aloscene.Frame.batch_list([frame])
-    frames = frames.to(device)
-
-    # GPU warm up
-    [model(frames) for _ in range(3)]
-
-    tic = time.time()
-    with torch.no_grad():
-        [model(frames) for _ in range(20)]
-    toc = time.time()
-    print(f"{(toc - tic)/20*1000} ms")
-
-    # Predict boxes/masks
-    m_outputs = model(frames)  # Pred of size (B, NQ, H//4, W//4)
-    pred_boxes, pred_masks = model.inference(m_outputs, frame_size=frames.HW, threshold=0.85)
-
-    # Add and display the boxes/masks predicted
-    frame.append_boxes2d(pred_boxes[0], "pred_boxes")
-    frame.append_segmentation(pred_masks[0], "pred_masks")
-    frame.get_view().render()
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Detr R50 Panoptic inference on image")
-    parser.add_argument("image_path", type=str, help="Path to the image for inference")
-    args = parser.parse_args()
-    main(args.image_path)

--- a/alonet/detr_panoptic/detr_r50_panoptic.py
+++ b/alonet/detr_panoptic/detr_r50_panoptic.py
@@ -1,0 +1,87 @@
+"""Module to create a :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` model, using
+:mod:`DetrR50 <alonet.detr.detr_r50>` as detection architecture.
+"""
+
+from argparse import Namespace
+from alonet.detr_panoptic import PanopticHead
+from alonet.detr import DetrR50
+
+
+class DetrR50Panoptic(PanopticHead):
+    """:mod:`DetrR50 <alonet.detr.detr_r50>` + :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>`
+
+    Parameters
+    ----------
+    num_classes : int, optional
+        Number of classes in the :attr:`class_embed` output layer, by default 250
+    background_class : int, optional
+        Background class, by default None
+    detr_weights : str, optional
+        Load weights to :mod:`DetrR50 <alonet.detr.detr_r50>`, by default None
+    weights : str, optional
+        Load weights from path or model_name, by default None
+    **kwargs
+        Initial parameters of :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` module
+
+    Raises
+    ------
+    ValueError
+        :attr:`weights` must be a '.pth' or '.ckpt' file
+    """
+
+    def __init__(
+        self,
+        num_classes: int = 250,
+        background_class: int = None,
+        detr_weights: str = None,
+        weights: str = None,
+        *args: Namespace,
+        **kwargs: dict,
+    ):
+        """Init method"""
+        base_model = DetrR50(num_classes=num_classes, background_class=background_class, weights=detr_weights)
+        super().__init__(*args, DETR_module=base_model, weights=weights, **kwargs)
+
+
+def main(image_path):
+    import torch
+    import time
+    import aloscene
+
+    device = torch.device("cuda")
+
+    # Load model
+    model = DetrR50Panoptic(weights="detr-r50-panoptic")
+    model.to(device).eval()
+
+    # Open and prepare a batch for the model
+    frame = aloscene.Frame(image_path).norm_resnet()
+    frames = aloscene.Frame.batch_list([frame])
+    frames = frames.to(device)
+
+    # GPU warm up
+    [model(frames) for _ in range(3)]
+
+    tic = time.time()
+    with torch.no_grad():
+        [model(frames) for _ in range(20)]
+    toc = time.time()
+    print(f"{(toc - tic)/20*1000} ms")
+
+    # Predict boxes/masks
+    m_outputs = model(frames)  # Pred of size (B, NQ, H//4, W//4)
+    pred_boxes, pred_masks = model.inference(m_outputs, frame_size=frames.HW, threshold=0.85)
+
+    # Add and display the boxes/masks predicted
+    frame.append_boxes2d(pred_boxes[0], "pred_boxes")
+    frame.append_segmentation(pred_masks[0], "pred_masks")
+    frame.get_view().render()
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser(description="Detr R50 Panoptic inference on image")
+    parser.add_argument("image_path", type=str, help="Path to the image for inference")
+    args = parser.parse_args()
+    main(args.image_path)

--- a/alonet/detr_panoptic/detr_r50_panoptic_finetune.py
+++ b/alonet/detr_panoptic/detr_r50_panoptic_finetune.py
@@ -3,14 +3,14 @@
 change the number of outputs in :attr:`class_embed` layer, in order to train custom classes.
 """
 
-from torch import nn
+import torch
 from argparse import Namespace
-from alonet.detr_panoptic import PanopticHead
-from alonet.detr import DetrR50
+
+from alonet.detr_panoptic import DetrR50Panoptic
 from alonet.common.weights import load_weights
 
 
-class DetrR50PanopticFinetune(PanopticHead):
+class DetrR50PanopticFinetune(DetrR50Panoptic):
     """Pre made helpfull class to finetune the :mod:`DetrR50 <alonet.detr.detr_r50>` and use a pretrained
     :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>`.
 
@@ -20,15 +20,16 @@ class DetrR50PanopticFinetune(PanopticHead):
         Number of classes in the :attr:`class_embed` output layer
     background_class : int, optional
         Background class, by default None
-    base_model : torch.nn, optional
-        Base model to couple PanopticHead, by default :mod:`DetrR50 <alonet.detr.detr_r50>`
     base_weights : str, optional
-        Load weights from original :mod:`DetrR50 <alonet.detr.detr_r50>` +
-        :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>`, by default "detr-r50-panoptic"
-    freeze_detr : bool, optional
-        Freeze :mod:`DetrR50 <alonet.detr.detr_r50>` weights, by default False
+        Load weights to the original :mod:`DetrR50Panoptic <alonet.detr_panoptic.detr_r50_panoptic>`,
+        by default "detr-r50-panoptic"
     weights : str, optional
-        Weights for finetune model, by default None
+        Load weights from path, by default None
+    use_bn_layers : bool, optional
+        Replace group norm layer in :mod:`PanopticHead <alonet.detr_panoptic.detr_panoptic>` by batch norm layer,
+        by default False
+    **kwargs
+        Initial parameters of :mod:`DetrR50panoptic <alonet.detr_panoptic.detr_r50_panoptic>` module
 
     Raises
     ------
@@ -40,24 +41,29 @@ class DetrR50PanopticFinetune(PanopticHead):
         self,
         num_classes: int,
         background_class: int = None,
-        base_model: nn = None,
         base_weights: str = "detr-r50-panoptic",
-        freeze_detr: bool = False,
         weights: str = None,
+        use_bn_layers: bool = False,
         *args: Namespace,
         **kwargs: dict,
     ):
         """Init method"""
-        base_model = base_model or DetrR50(*args, background_class=background_class, num_classes=250, **kwargs)
-        super().__init__(*args, DETR_module=base_model, freeze_detr=freeze_detr, weights=base_weights, **kwargs)
+        super().__init__(*args, weights=base_weights, **kwargs)
 
         self.detr.num_classes = num_classes
         # Replace the class_embed layer a new layer once the detr-r50 weight are loaded
         # + 1 to include the background class.
         self.detr.background_class = self.detr.num_classes if background_class is None else background_class
         self.detr.num_classes = num_classes + 1
-        self.detr.class_embed = nn.Linear(self.detr.hidden_dim, self.detr.num_classes)
+        self.detr.class_embed = torch.nn.Linear(self.detr.hidden_dim, self.detr.num_classes)
         self.detr.class_embed = self.detr.class_embed.to(self.device)
+
+        # Replace group by batch norm layers
+        if use_bn_layers:
+            for ignl in range(1, 6):
+                gname = "gn" + str(ignl)
+                glayer = getattr(self.mask_head, gname)
+                setattr(self.mask_head, gname, torch.nn.BatchNorm2d(glayer.num_channels))
 
         # Load weights procedure
         if weights is not None:

--- a/alonet/detr_panoptic/train.py
+++ b/alonet/detr_panoptic/train.py
@@ -23,7 +23,7 @@ class LitPanopticDetr(alonet.deformable_detr.LitDeformableDetr):
     accumulate_grad_batches : int, optional
         Accumulates grads every k batches or as set up in the dict, by default 4
     model_name : str, optional
-        Name use to define the model, by default "detr-r50-panoptic"
+        Name use to define the model, by default ``detr-r50-panoptic``
     model : torch.nn, optional
         Custom model to train
 
@@ -104,7 +104,7 @@ class LitPanopticDetr(alonet.deformable_detr.LitDeformableDetr):
         Raises
         ------
         Exception
-            Only :attr:`detr-r50-panoptic` models are supported yet.
+            Only ``detr-r50-panoptic`` models are supported yet.
         """
         if self.model_name == "detr-r50-panoptic":
             model = alonet.detr_panoptic.DetrR50Panoptic(
@@ -154,14 +154,14 @@ class LitPanopticDetr(alonet.deformable_detr.LitDeformableDetr):
             Weighting factor in range (0,1) to balance positive vs negative examples. -1 for no weighting,
             by default 0.25
         losses : list, optional
-            List of losses to take into account in total loss, by default ["labels", "boxes", "masks"].
-            Possible values: ["labels", "boxes", "masks"] (use the latest in segmentation tasks)
+            List of losses to take into account in total loss, by default [``labels``, ``boxes``, ``masks``] (uses all
+            the possible values).
         aux_loss_stage : int, optional
             Size of stages from :attr:`aux_outputs` key in forward ouputs, by default 6
 
         Returns
         -------
-        :mod:`DetrCriterion <alonet.detr.criterion>`
+        :mod:`DetrPanopticCriterion <alonet.detr_panoptic.criterion>`
             Criterion use to train the model
         """
         return alonet.detr_panoptic.DetrPanopticCriterion(
@@ -178,6 +178,22 @@ class LitPanopticDetr(alonet.deformable_detr.LitDeformableDetr):
         )
 
     def build_matcher(self, cost_class: float = 1, cost_boxes: float = 5, cost_giou: float = 2):
+        """Build the default matcher
+
+        Parameters
+        ----------
+        cost_class : float, optional
+            Weight of class cost in Hungarian Matcher, by default 1
+        cost_boxes : float, optional
+            Weight of boxes cost in Hungarian Matcher, by default 5
+        cost_giou : float, optional
+            Weight of GIoU cost in Hungarian Matcher, by default 2
+
+        Returns
+        -------
+        :mod:`DetrHungarianMatcher <alonet.detr.matcher>`
+            Hungarian Matcher, as a Pytorch model
+        """
         return alonet.detr.DetrHungarianMatcher(cost_class=cost_class, cost_boxes=cost_boxes, cost_giou=cost_giou)
 
     def callbacks(self, data_loader: Frame):

--- a/alonet/detr_panoptic/train_on_coco.py
+++ b/alonet/detr_panoptic/train_on_coco.py
@@ -24,7 +24,7 @@ def main():
     lit_panoptic = LitPanopticDetr(args)
 
     # Start training
-    lit_panoptic.run_train(data_loader=coco_loader, args=args, project="panoptic", expe_name="coco")
+    lit_panoptic.run_train(data_loader=coco_loader, args=args, project="detr-panoptic", expe_name="coco")
 
 
 if __name__ == "__main__":

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -179,28 +179,40 @@ class Renderer(object):
         return np.concatenate(lines, axis=0)
 
     def render(
-        self, views: list, renderer: str = "cv", cell_grid_size=None, record_file: str = None, fps=30, grid_size=None
+        self,
+        views: list,
+        renderer: str = "cv",
+        cell_grid_size=None,
+        record_file: str = None,
+        fps=30,
+        grid_size=None,
+        skip_views=False,
     ):
         """Render a list of view using the given renderer.
 
         Parameters
         ----------
-        views: list
+        views : list
             List of np.darray to display
-        renderer: str
+        renderer : str
             String to set the renderer to use. Can be either ("cv" or "matplotlib")
-        cell_grid_size: tuple
+        cell_grid_size : tuple
             Tuple or None. If not None, the tuple values (height, width) will be used
             to set the size of the each grid cell of the display. If only one view is used,
             the view will be resize to the cell grid size.
-        record_file: str
+        record_file : str
             None by default. Used to save the rendering into one video.
+        skip_views : bool, optional
+            Skip views, in order to speed up the render process, by default False
         """
         if renderer not in ["cv", "matplotlib"]:
-            raise Exception("The renderer must be one of the following:{}".format(self.renderer_to_fn.keys()))
-        view = self.get_grid_view(views, cell_grid_size=cell_grid_size, grid_size=grid_size)
-        self.renderer_to_fn[renderer](view)
+            raise ValueError("The renderer must be one of the following:{}".format(self.renderer_to_fn.keys()))
+        if skip_views and record_file is None:
+            raise ValueError("When skip_views is desired, a record_file must be provided.")
 
+        view = self.get_grid_view(views, cell_grid_size=cell_grid_size, grid_size=grid_size)
+        if not skip_views:
+            self.renderer_to_fn[renderer](view)
         if record_file is not None and self.out is None:
             self.out_shape = (view.shape[1], view.shape[0])
             self.out = cv2.VideoWriter(record_file, cv2.VideoWriter_fourcc(*"DIVX"), fps, self.out_shape)

--- a/docsource/source/alonet/panoptic.rst
+++ b/docsource/source/alonet/panoptic.rst
@@ -1,8 +1,7 @@
-Detr panoptic
+Panoptic Head
 ==========================
 
-The module allows the implementation of a neural network that connects the output of a |detr|_ for the prediction of
-segmentation maps, according to the boxes predicted from the base model.
+This module allows the implementation of a neural network based on |detr|_ to make prediction of segmentation maps.
 
 .. toctree::
    :maxdepth: 3

--- a/docsource/source/alonet/panoptic_models.rst
+++ b/docsource/source/alonet/panoptic_models.rst
@@ -1,7 +1,7 @@
 Models
 ======
 
-Panoptic Head is a pytorch module that implements a network to connect with the output of a
+Panoptic Head is a Pytorch module that implements a network to connect with the output of a
 :doc:`Detr-based model <detr_models>`. This new module is able to predict a segmentation features, represented by
 a binary mask for each object predicted by :doc:`Detr model <detr_models>`.
 
@@ -14,13 +14,16 @@ a binary mask for each object predicted by :doc:`Detr model <detr_models>`.
   `End-to-End Object Detection with Transformers <https://arxiv.org/pdf/2005.12872.pdf>`_ paper
 
 .. seealso::
-   :doc:`Mask </aloscene/mask>` object to know the data representation of predictions.
+
+   * :doc:`Mask </aloscene/mask>` object to know the data representation of predictions.
+   * `End-to-End Object Detection with Transformers <https://arxiv.org/pdf/2005.12872.pdf>`_ paper to understand how works
+     the architecture.
 
 Basic usage
 --------------------
 
-Given that :mod:`~alonet.detr_panoptic.detr_panoptic` implements the Panoptic Head for a |detr|_, first the module
-have to implement and be passed as :class:`~alonet.detr_panoptic.detr_panoptic.PanopticHead` parameter:
+Given that :mod:`~alonet.detr_panoptic.detr_panoptic` implements the Panoptic Head for a |detr|_, `DETR <detr>` mode
+must be defined as one of the first input parameter:
 
    .. code-block:: python
 
@@ -39,6 +42,40 @@ If you want to finetune from the model pretrained on COCO dataset, a |detrfine|_
 
       detr_model = DetrR50Finetune(num_classes=250)
       model = PanopticHead(DETR_module=detr_model)
+
+As experimental work, it is possible to couple |Deformable|_ to panoptic head, by its previous definition:
+
+   .. code-block:: python
+
+      from alonet.deformable_detr import DeformableDetrR50Finetune
+      from alonet.detr_panoptic import PanopticHead
+
+      detr_model = DeformableDetrR50Finetune(num_classes=250)
+      model = PanopticHead(DETR_module=detr_model)
+
+Or simply use the predefined models with resnet 50 backbone for DETR/Deformable DETR.
+
+   .. code-block:: python
+
+      from alonet.detr_panoptic import DetrR50Panoptic
+      from alonet.deformable_detr_panoptic import DeformableDetrR50Panoptic
+
+      # Use DetrR50 + PanopticHead and load pretrained weights
+      model DetrR50Panoptic(weights="detr-r50-panoptic")
+
+      # Use DeformableDetrR50Refinement + PanopticHead with its pretrained weights
+      model DeformableDetrR50Panoptic(
+         weights="deformable-detr-r50-panoptic-refinement",
+         activation_fn="softmax",
+         with_box_refine=True
+      )
+
+.. warning::
+
+   * As mentioned above, the work made on Deformable DETR is experimental, therefore the performance achieved differs
+     from that obtained with DETR. See |detrPerf|_ and |deformablePerf|_
+   * Unlike the :doc:`Deformable DETR <deformable>`, the weights provided by :doc:`Aloception </index>` were trained
+     for the :mod:`DeformableDetrR50Refinement <alonet.deformable_detr.deformable_detr_r50_refinement>` architecture.
 
 To run an inference:
 
@@ -75,6 +112,13 @@ Panoptic head API
    :undoc-members:
    :show-inheritance:
 
+DetrR50 Panoptic
+-----------------------------------------------
+
+.. automodule:: alonet.detr_panoptic.detr_r50_panoptic
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 DetrR50 Panoptic Finetune
 -----------------------------------------------
@@ -84,8 +128,31 @@ DetrR50 Panoptic Finetune
    :undoc-members:
    :show-inheritance:
 
+Deformable DetrR50 Panoptic
+-----------------------------------------------
+
+.. automodule:: alonet.deformable_detr_panoptic.deformable_detr_r50_panoptic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Deformable DetrR50 Panoptic Finetune
+-----------------------------------------------
+
+.. automodule:: alonet.deformable_detr_panoptic.deformable_detr_r50_panoptic_finetune
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. Hyperlinks
 .. |detr| replace:: Detr-based models
 .. _detr: detr_models.html#module-alonet.detr.detr
+.. |deformable| replace:: Deformable-based models
+.. _deformable: deformable_models.html#module-alonet.deformable_detr.deformable_detr
 .. |detrfine| replace:: DetrFinetune models
 .. _detrfine: detr_models.html#module-alonet.detr.detr_r50_finetune
+
+.. _detrPerf: https://github.com/Visual-Behavior/aloception/tree/master/alonet/detr_panoptic
+.. |detrPerf| replace:: DETR results
+.. _deformablePerf: https://github.com/Visual-Behavior/aloception/tree/master/alonet/deformable_panoptic
+.. |deformablePerf| replace:: Deformable DETR results

--- a/docsource/source/alonet/panoptic_training.rst
+++ b/docsource/source/alonet/panoptic_training.rst
@@ -1,13 +1,25 @@
 Training
 =========================
 
-For training, :mod:`LitPanopticDetr <alonet.detr_panoptic.train>` implements a
-`Pytorch Lightning Module <https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html>`_ that
-uses as default the :mod:`~alonet.detr.detr_r50` module coupled with :mod:`~alonet.detr_panoptic.detr_panoptic`.
-For this reason, :mod:`alonet.detr.criterion` and :mod:`alonet.detr.matcher` are used in the training. However,
-the :mod:`alonet.detr_panoptic.callbacks` are adapted to the predictions of the masks in the inference process.
+For training, :mod:`LitPanopticDetr <alonet.detr_panoptic.train>` and
+:mod:`LitPanopticDeformableDetr <alonet.deformable_detr_panoptic.train>` are
+`Pytorch Lightning Modules <https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html>`_, with
+:mod:`~alonet.detr_panoptic.detr_r50_panoptic` and :mod:`~alonet.deformable_detr_panoptic.deformable_detr_r50_panoptic`
+as default architectures, respectively.
 
-Training
+The :mod:`DETR Panoptic Criterion <alonet.detr_panoptic.criterion>` and
+:mod:`Deformable DETR Panoptic Criterion <alonet.deformable_detr_panoptic.criterion>` inherit the
+:mod:`DETR criterion <alonet.detr.criterion>`/:mod:`Deformable DETR criterion <alonet.deformable_detr.criterion>`,
+adding to each one the :class:`~alonet.detr_panoptic.criterion.PanopticCriterion`.
+
+Finally, :mod:`alonet.detr_panoptic.callbacks` adapts the segmentation predictions at the inference process on
+training-loop, for both architectures.
+
+.. note::
+
+   :mod:`alonet.detr.matcher` and :mod:`alonet.deformable_detr.matcher` are the matcher used in training
+
+LitPanopticDetr
 ------------------------------------
 
 .. automodule:: alonet.detr_panoptic.train
@@ -15,7 +27,52 @@ Training
    :undoc-members:
    :show-inheritance:
 
-Callbacks
+LitPanopticDeformableDetr
+------------------------------------
+
+.. automodule:: alonet.deformable_detr_panoptic.train
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Panoptic Criterion
+----------------------------------------
+
+.. autoclass:: alonet.detr_panoptic.criterion.PanopticCriterion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Detr Panoptic Criterion
+----------------------------------------
+
+This class computes the loss for :mod:`DETR_PANOPTIC <alonet.detr_panoptic.detr_panoptic>`. The process happens
+in two steps:
+
+1) We compute hungarian assignment between ground truth boxes and the outputs of the model
+2) We supervise each pair of matched ground-truth / prediction (supervise class, boxes and masks).
+
+.. autoclass:: alonet.detr_panoptic.criterion.DetrPanopticCriterion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Deformable Detr Panoptic Criterion
+----------------------------------------
+
+This class computes the loss for
+:mod:`DEFORMABLE DETR PANOPTIC <alonet.deformable_detr_panoptic.deformable_detr_panoptic>`.
+The process happens in two steps:
+
+1) We compute hungarian assignment between ground truth boxes and the outputs of the model
+2) We supervise each pair of matched ground-truth / prediction (supervise class, boxes and masks).
+
+.. autoclass:: alonet.deformable_detr_panoptic.criterion.DeformablePanopticCriterion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Detr Panoptic Callbacks
 ----------------------------------------
 
 .. automodule:: alonet.detr_panoptic.callbacks
@@ -23,19 +80,20 @@ Callbacks
    :undoc-members:
    :show-inheritance:
 
-.. Criterion
-.. ----------------------------------------
-
-.. .. automodule:: alonet.detr.criterion
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
-
+.. automodule:: alonet.deformable_detr_panoptic.callbacks
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. Matcher
 .. --------------------------------------
 
 .. .. automodule:: alonet.detr.matcher
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:
+
+.. .. automodule:: alonet.deformable_detr.matcher
 ..    :members:
 ..    :undoc-members:
 ..    :show-inheritance:


### PR DESCRIPTION
DeformablePanoptic stand-alone module creation

News:
 * DeformableDetrR50Panoptic and DeformableDetrR50PanopticFinetune
 * Incluse skip Views in render function, to produce videos more faster and compatibility with GNU-screen.

Fixed:
 * In `Data2Detr`, implement `train_dataset`  and `val_dataset` as class propierties, removing `self.setup()` from `__init__`.  With this, the datasets are configured only if the user wants to read the datasets.
 * In `CocoPanopticDataset`, there was problems between the alignment of super-categories and categories. Fixed

Documentation updated

Ready to merge @thibo73800 