### PR TITLE
bugfix: make depth label mergeable

### DIFF
--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -110,7 +110,7 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.add_child("boxes3d", boxes3d, align_dim=["B", "T"], mergeable=False)
         tensor.add_child("flow", flow, align_dim=["B", "T"], mergeable=False)
         tensor.add_child("disparity", disparity, align_dim=["B", "T"], mergeable=True)
-        tensor.add_child("depth", depth, align_dim=["B", "T"], mergeable=False)
+        tensor.add_child("depth", depth, align_dim=["B", "T"], mergeable=True)
         tensor.add_child("segmentation", segmentation, align_dim=["B", "T"], mergeable=False)
         tensor.add_child("labels", labels, align_dim=["B", "T"], mergeable=True)
 


### PR DESCRIPTION
Bug :
- depth label in `aloscene.Frame` is not mergeable, but I don't see any case where it should not be.

Fix: 
- make depth label mergeable

@Johansmm 
@thibo73800 