### PR TITLE
Trt export from onnx

### DIFF
--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -284,6 +284,8 @@ class BaseTRTExporter:
             path_split[-1] = "trt_" + path_split[-1]
             self.onnx_path = "/".join(path_split)
 
+        print("self.onnx_path", self.onnx_path)
+
         # === Build engine
         self.engine_builder.export_engine(self.engine_path)
         return self.engine_builder.engine

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -270,10 +270,10 @@ class BaseTRTExporter:
         if prod_package_error is not None:
             raise prod_package_error
 
-        graph = gs.import_onnx(onnx.load(self.onnx_path))
-        graph.toposort()
-
         if not self.skip_adapt_graph:
+            graph = gs.import_onnx(onnx.load(self.onnx_path))
+            graph.toposort()
+
             # === Modify ONNX graph for TensorRT compability
             graph = self.adapt_graph(graph, **kwargs)
             utils.print_graph_io(graph)
@@ -283,8 +283,6 @@ class BaseTRTExporter:
             path_split = self.onnx_path.split("/")
             path_split[-1] = "trt_" + path_split[-1]
             self.onnx_path = "/".join(path_split)
-
-        print("self.onnx_path", self.onnx_path)
 
         # === Build engine
         self.engine_builder.export_engine(self.engine_path)

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -1,7 +1,6 @@
 import io
 import os
 import time
-from tkinter import E
 from typing import Dict, List, Tuple, Union
 
 
@@ -22,7 +21,7 @@ except Exception as prod_package_error:
 from contextlib import redirect_stdout, ExitStack
 from alonet.torch2trt.onnx_hack import scope_name_workaround, get_scope_names, rename_tensors_
 from alonet.torch2trt import TRTEngineBuilder, TRTExecutor, utils
-
+from alonet.torch2trt.utils import get_nodes_by_op, rename_nodes_
 
 
 
@@ -122,13 +121,19 @@ class BaseTRTExporter:
         onnx_dir = os.path.split(onnx_path)[0]
         onnx_file_name = os.path.split(onnx_path)[1]
         model_name = onnx_file_name.split(".")[0]
-        self.adapted_onnx_path = os.path.join(onnx_dir, "trt_" + onnx_file_name)
+
+        if not self.skip_adapt_graph:
+            self.adapted_onnx_path = os.path.join(onnx_dir, "trt_" + onnx_file_name)
+        else:
+            self.adapted_onnx_path = os.path.join(onnx_dir, onnx_file_name)
+
         self.engine_path = os.path.join(onnx_dir, model_name + f"_{precision.lower()}.engine")
 
         if self.verbose:
             trt_logger = trt.Logger(trt.Logger.VERBOSE)
         else:
             trt_logger = trt.Logger(trt.Logger.WARNING)
+
         self.engine_builder = TRTEngineBuilder(self.adapted_onnx_path, logger=trt_logger, opt_profiles=opt_profiles)
 
         if precision.lower() == "fp32":
@@ -152,15 +157,62 @@ class BaseTRTExporter:
         pass
         raise Exception("Child class should implement this method")
 
-    def adapt_graph(self, graph):
+
+
+    def adapt_graph(self, graph: gs.Graph):
         """Modify ONNX graph to ensure compability between ONNX and TensorRT
 
         Returns
         -------
         graph: onnx_graphsurgeon.Graph
         """
-        pass
-        raise Exception("Child class should implement this method")
+        return graph
+
+    def _adapt_graph(self, graph):
+        """Modify ONNX graph to ensure compability between ONNX and TensorRT
+
+        Returns
+        -------
+        graph: onnx_graphsurgeon.Graph
+        """
+        clip_nodes = get_nodes_by_op("Clip", graph)
+        def handle_op_Clip(node: gs.Node):
+            max_constant = np.array(np.finfo(np.float32).max, dtype=np.float32)
+            if "value" in node.inputs[1].i().inputs[0].attrs:
+                min_constant = node.inputs[1].i().inputs[0].attrs["value"].values.astype(np.float32)
+                if len(node.inputs[2].inputs) > 0:
+                    max_constant = node.inputs[2].i().inputs[0].attrs["value"].values.astype(np.float32)
+            elif "to" in node.inputs[1].i().inputs[0].attrs:
+                min_constant = np.array(np.finfo(np.float32).min, dtype=np.float32)
+            else:
+                raise Exception("Error")
+            node.inputs.pop(1)
+            node.inputs.insert(1, gs.Constant(name=node.name + "_min", values=min_constant))
+            node.inputs.pop(2)
+            node.inputs.insert(2, gs.Constant(name=node.name + "_max", values=max_constant))
+
+        for n in clip_nodes:
+            handle_op_Clip(n)
+
+        from onnxsim import simplify
+        model = onnx.load(self.onnx_path)
+        check = False
+        model_simp, check = simplify(model)
+
+        if check:
+            print("\n[INFO] Simplified ONNX model validated. Graph optimized...")
+            graph = gs.import_onnx(model_simp)
+            graph.toposort()
+            graph.cleanup()
+        else:
+            print("\n[INFO] ONNX model was not validated.")
+
+        if self.use_scope_names:  # Rename nodes to correct profiling
+            graph = rename_nodes_(graph, True)
+
+        # Call the child class for specific graph adapation
+        graph = self.adapt_graph(graph)
+        return graph
 
     def prepare_sample_inputs(self) -> Tuple[Tuple[torch.Tensor], Dict[str, Union[torch.Tensor, None]]]:
         """
@@ -275,14 +327,10 @@ class BaseTRTExporter:
             graph.toposort()
 
             # === Modify ONNX graph for TensorRT compability
-            graph = self.adapt_graph(graph, **kwargs)
+            graph = self._adapt_graph(graph, **kwargs)
             utils.print_graph_io(graph)
             # === Export adapted onnx for TRT engine
             onnx.save(gs.export_onnx(graph), self.adapted_onnx_path)
-        else:
-            path_split = self.onnx_path.split("/")
-            path_split[-1] = "trt_" + path_split[-1]
-            self.onnx_path = "/".join(path_split)
 
         # === Build engine
         self.engine_builder.export_engine(self.engine_path)
@@ -342,7 +390,13 @@ class BaseTRTExporter:
             default=None,
             help="/path/onnx/will/be/exported, by default set as ~/.aloception/weights/MODEL/MODEL.onnx",
         )
+        parser.add_argument("--skip_adapt_graph", action="store_true", help="Skip the adapt graph")
         parser.add_argument("--batch_size", type=int, default=1, help="Engine batch size, default = 1")
         parser.add_argument("--precision", type=str, default="fp32", help="fp32/fp16/mix, default FP32")
         parser.add_argument("--verbose", action="store_true", help="Helpful when debugging")
+        parser.add_argument(
+            "--use_scope_names",
+            action="store_true",
+            help="Save scope names in onnx, to get profiles in inference by default %(default)s",
+        )
         return parent_parser

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -13,7 +13,7 @@ try:
     import onnx
     import onnx_graphsurgeon as gs
     import tensorrt as trt
-
+    import pycuda.driver as cuda
     prod_package_error = None
 except Exception as prod_package_error:
     pass
@@ -24,7 +24,7 @@ from alonet.torch2trt.onnx_hack import scope_name_workaround, get_scope_names, r
 from alonet.torch2trt import TRTEngineBuilder, TRTExecutor, utils
 
 
-import pycuda.driver as cuda
+
 
 class BaseTRTExporter:
     """

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -158,8 +158,7 @@ class BaseTRTExporter:
         raise Exception("Child class should implement this method")
 
 
-
-    def adapt_graph(self, graph: gs.Graph):
+    def adapt_graph(self, graph):
         """Modify ONNX graph to ensure compability between ONNX and TensorRT
 
         Returns
@@ -207,8 +206,6 @@ class BaseTRTExporter:
         else:
             print("\n[INFO] ONNX model was not validated.")
 
-        if self.use_scope_names:  # Rename nodes to correct profiling
-            graph = rename_nodes_(graph, True)
 
         # Call the child class for specific graph adapation
         graph = self.adapt_graph(graph)
@@ -304,6 +301,7 @@ class BaseTRTExporter:
             number2scope = get_scope_names(onnx_export_log, strict=False)
             graph = gs.import_onnx(onnx.load(self.onnx_path))
             graph = rename_tensors_(graph, number2scope, verbose=True)
+            graph = rename_nodes_(graph, True)
             onnx.save(gs.export_onnx(graph), self.onnx_path)
 
         print("Saved ONNX at:", self.onnx_path)

--- a/alonet/torch2trt/utils.py
+++ b/alonet/torch2trt/utils.py
@@ -368,3 +368,37 @@ def execute_sync(context, bindings, inputs, outputs):
     for out in outputs:
         out.host = out.host.reshape(out.shape)
     return [out.host for out in outputs]
+
+
+
+def rename_nodes_(graph, verbose=False):
+
+    dont_rename = [v.name for v in graph.inputs + graph.outputs]
+
+    for node in graph.nodes:
+        if node.name not in dont_rename:
+            # Replace name by output name to include in profiling
+            node.name = node.outputs[0].name
+            # If the node does not have name, try to replace by inputs tensors to it
+            try:
+                id_node = int(node.name)
+                node_is_int = True
+            except:
+                node_is_int = False
+
+            if node_is_int:
+                for inode in node.inputs:
+                    try:  # Only for named inputs
+                        int(inode.name)
+                        inode_is_int = True
+                    except:
+                        inode_is_int = False
+
+                    # Input named, change tensor name
+                    if not inode_is_int:
+                        new_name = inode.name + "_" + str(id_node)
+                        if verbose:
+                            print(f"  changed {node.name} to {new_name}")
+                        node.name = new_name
+
+    return graph


### PR DESCRIPTION
In this merge request

**Fix and features**
- add `skip_adapt_graph` option to not adapt the graph before to export to TensorRT.
- Fix issue when calling `TRTExecutor()` without engine, its now `TRTExecutor(stream=cuda.Stream())`
- Automatically adapt graph by default: handle clip operations + simplify onnx graph. Is is not mandatory to override this method anymore. This change will not affect the current trt exporter since the `adapt_graph` method is supposed to be override. 

 