### PR TITLE
Fix model none on BaseTRTExporter

### DIFF
--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -98,7 +98,8 @@ class BaseTRTExporter:
         if prod_package_error is not None:
             raise prod_package_error
 
-        assert hasattr(model, "tracing") and model.tracing, "Model must be instantiated with tracing=True"
+        if model is not None:
+            assert hasattr(model, "tracing") and model.tracing, "Model must be instantiated with tracing=True"
         self.model = model
         self.input_names = input_names
         self.onnx_path = onnx_path


### PR DESCRIPTION
- `BaseTRTExporter` can now be create from a None model. This is usefull if one want to only export from an onnx file.