### PR TITLE
add depth absolute/relative encoding

### DIFF
--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -49,11 +49,25 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
     def __init__(self, x, *args, **kwargs):
         super().__init__(x)
 
-    def encode_inverse(
-            self, 
-            scale: float = 1, 
-            shift: float = 0):
-        """Shift and scales the depth values"""
+    def encode_inverse(self, scale=1, shift=0):
+        """Scales and shifts the inverse depth
+        
+        Parameters
+        ----------
+            scale: (: float)
+                Multiplication factor. Default is 1.
+            
+            shift: (: float)
+                Addition intercept. Default is 0.
+        
+        Exemples
+        -------
+        >>> # Create a non inverted depth
+        >>> depth = aloscene.Depth(np.random.normal((1, 20, 20)))
+        >>> inverted_depth = depth.encode_inverse(scale=0.03, shift=1)
+        >>> depth.is_inverse, inverted_depth.is_inverse
+        >>> False, True
+        """
         depth = self
         if depth._is_inverse:
             depth = self.encode_absolute()
@@ -64,7 +78,16 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         return 1 / depth
     
     def encode_absolute(self):
-        """Undo inverse encoding"""
+        """Encodes inverted depth to absolute depth
+        
+        Exemples
+        --------
+        >>> # Create an already inverted depth
+        >>> invert_depth = aloscene.Depth(np.random.normal((1, 20, 20)), scale=0.5, shift=1)
+        >>> depth = depth.encode_absolute(scale=0.03, shift=1)
+        >>> depth.is_inverse, inverted_depth.is_inverse
+        >>> False, True
+        """
         depth = self
         if not depth._is_inverse:
             warnings.warn('depth already encoded in absolute mode')

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -41,9 +41,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             names = ("C", "H", "W")
         tensor = super().__new__(cls, x, *args, names=names, **kwargs)
         tensor.add_child("occlusion", occlusion, align_dim=["B", "T"], mergeable=True)
-        tensor.add_property('_scale', scale)
-        tensor.add_property('_shift', shift)
-        tensor.add_property('_is_inverse', is_inverse)
+        tensor.add_property('scale', scale)
+        tensor.add_property('shift', shift)
+        tensor.add_property('is_inverse', is_inverse)
         return tensor
 
     def __init__(self, x, *args, **kwargs):
@@ -71,9 +71,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         depth = self
         if depth._is_inverse:
             depth = self.encode_absolute()
-        depth.add_property('_scale', scale)
-        depth.add_property('_shift', shift)
-        depth.add_property('_is_inverse', True)
+        depth.add_property('scale', scale)
+        depth.add_property('shift', shift)
+        depth.add_property('is_inverse', True)
         depth = depth * scale + shift
         return 1 / depth
     

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -59,7 +59,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         super().__init__(x)
 
     def encode_inverse(self):
-        """Undo encode_absolute rtansformation
+        """Undo encode_absolute tansformation
         
         Exemples
         -------
@@ -97,15 +97,15 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> absolute_depth.is_absolute, not_absolute_depth.is_absolute
         >>> True, False
         """
-        depth = self
+        depth, names = self.rename(None), self.names
         if depth.is_absolute:
             raise ExecError('depth already in absolute state, call encode_inverse first')
         depth = depth * scale + shift
-        depth[depth < 1e-8] = 1e-8
+        depth[torch.unsqueeze(depth < 1e-8, dim=0)] = 1e-8
         depth.scale = scale
         depth.shift = shift
         depth.is_absolute = True
-        return 1 / depth
+        return (1 / depth).rename(*names)
 
     def append_occlusion(self, occlusion: Mask, name: str = None):
         """Attach an occlusion mask to the depth tensor.

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -49,7 +49,10 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
     def __init__(self, x, *args, **kwargs):
         super().__init__(x)
 
-    def encode_inverse(self, scale: float, shift: float):
+    def encode_inverse(
+            self, 
+            scale: float = 1, 
+            shift: float = 0):
         """Shift and scales the depth values"""
         depth = self.detach().cpu()
         if depth._is_inverse:

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -54,7 +54,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             scale: float = 1, 
             shift: float = 0):
         """Shift and scales the depth values"""
-        depth = self.detach().cpu()
+        depth = self
         if depth._is_inverse:
             depth = self.encode_absolute()
         depth.add_property('_scale', scale)
@@ -65,7 +65,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
     
     def encode_absolute(self):
         """Undo inverse encoding"""
-        depth = self.detach().cpu()
+        depth = self
         if not depth._is_inverse:
             warnings.warn('depth already encoded in absolute mode')
             return depth

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -69,7 +69,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> (undo_depth == not_absolute_depth).item()
         >>> True
         """
-        depth = self.clone()
+        depth = self
         if not depth.is_absolute:
             raise ExecError('can not inverse depth, already inversed')
         depth = 1 / depth
@@ -97,7 +97,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> absolute_depth.is_absolute, not_absolute_depth.is_absolute
         >>> True, False
         """
-        depth = self.clone()
+        depth = self
         if depth.is_absolute:
             raise ExecError('depth already in absolute state, call encode_inverse first')
         depth = depth * scale + shift

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -101,6 +101,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         if depth.is_absolute:
             raise ExecError('depth already in absolute state, call encode_inverse first')
         depth = depth * scale + shift
+        depth[depth < 1e-8] = 1e-8
         depth.scale = scale
         depth.shift = shift
         depth.is_absolute = True

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -21,6 +21,12 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         loaded Depth tensor or path to the Depth file from which Depth will be loaded.
     occlusion : aloscene.Mask
         Occlusion mask for this Depth map. Default value : None.
+    is_inverse: bool
+        Either the depth is already or not inverted.
+    scale: float
+        Scale used to to shift depth. Pass this argument only if is_inverse is set to True
+    shift: float
+        Intercept used to shift depth. Pass this argument only if is_inverse is set to True
     """
 
     @staticmethod

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -75,7 +75,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> False, True
         """
         depth = self
-        if depth._is_inverse:
+        if depth.is_inverse:
             depth = self.encode_absolute()
         depth.scale = scale
         depth.shift = shift
@@ -95,11 +95,11 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> False, True
         """
         depth = self
-        if not depth._is_inverse:
+        if not depth.is_inverse:
             warnings.warn('depth already encoded in absolute mode')
             return depth
         depth = 1 / depth
-        depth = depth / self.scale - self.shift
+        depth = (depth - self.shift) / self.scale
         depth.scale = None
         depth.shift = None
         depth.is_inverse = False

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -77,9 +77,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         depth = self
         if depth._is_inverse:
             depth = self.encode_absolute()
-        depth.add_property('scale', scale)
-        depth.add_property('shift', shift)
-        depth.add_property('is_inverse', True)
+        depth.scale = scale
+        depth.shift = shift
+        depth.is_inverse = True
         depth = depth * scale + shift
         return 1 / depth
     
@@ -100,9 +100,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             return depth
         depth = 1 / depth
         depth = depth / self.scale - self.shift
-        depth.add_property('_scale', None)
-        depth.add_property('_shift', None)
-        depth.add_property('_is_inverse', False)
+        depth.scale = None
+        depth.shift = None
+        depth.is_inverse = False
         return depth
 
     def append_occlusion(self, occlusion: Mask, name: str = None):

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -1,7 +1,7 @@
-import aloscene
 import torch
-from typing import *
 import inspect
+import numpy as np
+from typing import *
 
 
 class AugmentedTensor(torch.Tensor):
@@ -699,6 +699,10 @@ class AugmentedTensor(torch.Tensor):
         n_tensor.__class__ = torch.Tensor
         n_tensor.rename_(None)
         return n_tensor
+    
+    def to_squeezed_numpy(self):
+        """Returns squeezed numpy array"""
+        return self.squeeze().cpu().detach().numpy().astype(np.float16)
 
     def __repr__(self):
         _str = self.as_tensor().__repr__()

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -709,7 +709,7 @@ class AugmentedTensor(torch.Tensor):
                 The output dtype. Default np.float16.
         """
         tensor = self
-        return np.squeeze(tensor.detach().cpu().numpy()).astype(dtype)
+        return tensor.detach().cpu().numpy().astype(dtype)
 
     def __repr__(self):
         _str = self.as_tensor().__repr__()

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -701,7 +701,13 @@ class AugmentedTensor(torch.Tensor):
         return n_tensor
     
     def as_numpy(self, dtype=np.float16):
-        """Returns squeezed numpy array"""
+        """Returns squeezed numpy array
+        
+        Parameters
+        ----------
+            dtype: (: np.dtype)
+                The output dtype. Default np.float16.
+        """
         tensor = self
         return np.squeeze(tensor.detach().cpu().numpy()).astype(dtype)
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -700,9 +700,10 @@ class AugmentedTensor(torch.Tensor):
         n_tensor.rename_(None)
         return n_tensor
     
-    def to_squeezed_numpy(self):
+    def as_numpy(self, dtype=np.float16):
         """Returns squeezed numpy array"""
-        return self.squeeze().cpu().detach().numpy().astype(np.float16)
+        tensor = self
+        return np.squeeze(tensor.detach().cpu().numpy()).astype(dtype)
 
     def __repr__(self):
         _str = self.as_tensor().__repr__()


### PR DESCRIPTION
Two methods added to **Depth:**
- encode_inverse : invert depth with given scale and shift.
- encode_absolute : undo encode_inverse changes.

One method added to **AugTensor:**
- to_squeezed_numpy: as its name indicates, converts to squeezed numpy.