### PR TITLE
fixe project run_id default

### DIFF
--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -160,12 +160,16 @@ def load_training(
     args: Namespace = None,
     run_id: str = None,
     project_run_id: str = None,
+    no_run_id: bool = None,
     **kwargs,
 ):
     """Load training"""
     run_id = args.run_id if run_id is None and "run_id" in args else run_id
     project_run_id = args.project_run_id if project_run_id is None and "project_run_id" in args else project_run_id
     weights_path = getattr(args, "weights", None) if args is not None else None
+    no_run_id = args.no_run_id if no_run_id is None and "no_run_id" in args else no_run_id
+
+
     if "weights" in kwargs and kwargs["weights"] is not None:  # Highest priority
         weights_path = kwargs["weights"]
 
@@ -187,7 +191,7 @@ def load_training(
             lit_model = lit_model_class.load_from_checkpoint(weights_path, strict=strict, args=args, **kwargs)
         else:
             raise Exception(f"Impossible to load the weights at the following destination:{weights_path}")
-    elif args.no_run_id:
+    elif no_run_id:
         lit_model = lit_model_class(args=args, **kwargs)
     else:
         raise Exception("--run_id (optionally --project_run_id) must be given to load the experiment.")


### PR DESCRIPTION
In this merge request:

- Fixe when using `load_training` without loading the common argparse, the `no_run_id` was used in load_training.  I now use a default value if the value is not set into the args.
