### PR TITLE
Noisy aug, pose update, depth abs, render, batch_list

### DIFF
--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -622,13 +622,14 @@ class RealisticNoise(AloTransform):
     def apply(self, frame: Frame):
         n_frame = frame.norm01()
 
-        gaussian_noise = torch.normal(mean=0, std=self.gaussian_std, size=frame.shape)
-        shot_noise = torch.normal(mean=0, std=self.shot_std, size=frame.shape)
+        gaussian_noise = torch.normal(mean=0, std=self.gaussian_std, size=frame.shape, device=frame.device)
+        shot_noise = torch.normal(mean=0, std=self.shot_std, size=frame.shape, device=frame.device)
         noisy_frame = n_frame + n_frame * n_frame * shot_noise + gaussian_noise
         noisy_frame = torch.clip(noisy_frame, 0, 1)
 
-        if n_frame.normalization != frame.normalization:
-            n_frame = n_frame.norm_as(frame)
+        if noisy_frame.normalization != frame.normalization:
+            noisy_frame = noisy_frame.norm_as(frame)
+
         return noisy_frame
 
 

--- a/aloscene/__init__.py
+++ b/aloscene/__init__.py
@@ -8,6 +8,7 @@ from .depth import Depth
 from .points_2d import Points2D
 from .points_3d import Points3D
 from .disparity import Disparity
+from .pose import Pose
 from .bounding_boxes_2d import BoundingBoxes2D
 from .bounding_boxes_3d import BoundingBoxes3D
 from .oriented_boxes_2d import OrientedBoxes2D

--- a/aloscene/__init__.py
+++ b/aloscene/__init__.py
@@ -13,3 +13,57 @@ from .bounding_boxes_2d import BoundingBoxes2D
 from .bounding_boxes_3d import BoundingBoxes3D
 from .oriented_boxes_2d import OrientedBoxes2D
 from .frame import Frame
+from .tensors.spatial_augmented_tensor import SpatialAugmentedTensor
+
+from .renderer import Renderer
+
+def batch_list(tensors):
+    return SpatialAugmentedTensor.batch_list(tensors)
+
+_renderer = None
+def render(
+        views: list,
+        renderer: str = "cv",
+        size=None,
+        record_file: str = None,
+        fps=30,
+        grid_size=None,
+        skip_views=False,
+    ):
+    """Render a list of view.
+
+    Parameters
+    ----------
+    views : list
+        List of np.darray to display
+    renderer : str
+        String to set the renderer to use. Can be either ("cv" or "matplotlib")
+    cell_grid_size : tuple
+        Tuple or None. If not None, the tuple values (height, width) will be used
+        to set the size of the each grid cell of the display. If only one view is used,
+        the view will be resize to the cell grid size.
+    record_file : str
+        None by default. Used to save the rendering into one video.
+    skip_views : bool, optional
+        Skip views, in order to speed up the render process, by default False
+    """
+    global _renderer
+    _renderer = Renderer() if _renderer is None else _renderer
+
+    _renderer.render(
+        views=views,
+        renderer=renderer,
+        cell_grid_size=size,
+        record_file=record_file,
+        fps=fps,
+        grid_size=grid_size,
+        skip_views=skip_views
+    )
+
+
+def save_renderer():
+    """If render() was called with a `record_file`, then this method will
+    save the final video on the system. Warning: It is currently not possible
+    to save multiple stream directly with aloception. Todo so, one can manually create multiple `Renderer`.
+    """
+    _renderer.save()

--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -187,6 +187,23 @@ class CameraExtrinsic(AugmentedTensor):
         tensor = super().__new__(cls, x, *args, **kwargs)
         return tensor
 
+    def translation_with(self, tgt_pos):
+        """ Compute the translation with an other pos
+
+        Parameters
+        ----------
+        tgt_pos: aloscene.Pose
+            Target pose to compute the translation with
+
+        Returns
+        -------
+        n_pos: torch.tensor
+            Translation tensor of shape (..., 3)
+        """
+        Ttgt2self = torch.linalg.solve(self.as_tensor(), tgt_pos.as_tensor())
+        translation = Ttgt2self[..., :3, -1]
+        return translation
+
     def __init__(self, x, *args, **kwargs):
         assert x.shape[-2] == 4 and x.shape[-1] == 4
         super().__init__(x)

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -6,7 +6,7 @@ from typing import TypeVar, Union
 
 import aloscene
 from aloscene.renderer import View
-from aloscene import BoundingBoxes2D, BoundingBoxes3D, Depth, Disparity, Flow, Mask, Labels, Points2D, Points3D
+from aloscene import BoundingBoxes2D, BoundingBoxes3D, Depth, Disparity, Flow, Mask, Labels, Points2D, Points3D, Pose
 
 # from aloscene.camera_calib import CameraExtrinsic, CameraIntrinsic
 from aloscene.io.image import load_image
@@ -113,6 +113,7 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.add_child("depth", depth, align_dim=["B", "T"], mergeable=True)
         tensor.add_child("segmentation", segmentation, align_dim=["B", "T"], mergeable=False)
         tensor.add_child("labels", labels, align_dim=["B", "T"], mergeable=True)
+        tensor.add_child("pose", labels, align_dim=["B", "T"], mergeable=True)
 
         # Add other tensor property
         tensor.add_property("normalization", normalization)
@@ -303,6 +304,19 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
             mask are attached to the frame, the mask will be added to the set of mask.
         """
         self._append_child("segmentation", segmentation, name)
+
+    def append_pose(self, pose: Pose, name: str = None):
+        """Attach a pose to the frame.
+
+        Parameters
+        ----------
+        pose : :mod:`Pose <aloscene.pose>`
+            Depth to attach to the Frame
+        name : str
+            If none, the pose will be attached without name (if possible). Otherwise if no other unnamed
+            pose is attached to the frame, the pose will be added to the set of poses.
+        """
+        self._append_child("pose", pose, name)
 
     @staticmethod
     def _get_mean_std_tensor(shape, names, mean_std: tuple, device="cpu"):

--- a/aloscene/pose.py
+++ b/aloscene/pose.py
@@ -1,8 +1,9 @@
-from aloscene.tensors.augmented_tensor import AugmentedTensor
+from aloscene.camera_calib import CameraExtrinsic
+import torch
 
 
-class Pose(AugmentedTensor):
-    """Pose Tensor.
+class Pose(CameraExtrinsic):
+    """Pose Tensor. Usually use to store World2Frame coordinates
 
     Parameters
     ----------
@@ -17,3 +18,21 @@ class Pose(AugmentedTensor):
 
     def __init__(self, x, *args, **kwargs):
         super().__init__(x)
+
+    def _hflip(self, *args, **kwargs):
+        return self.clone()
+
+    def _vflip(self, *args, **kwargs):
+        return self.clone()
+
+    def _resize(self, *args, **kwargs):
+        # Resize image does not change cam extrinsic
+        return self.clone()
+
+    def _crop(self, *args, **kwargs):
+        # Cropping image does not change cam extrinsic
+        return self.clone()
+
+    def _pad(self, *args, **kwargs):
+        # Padding image does not change cam extrinsic
+        return self.clone()

--- a/aloscene/pose.py
+++ b/aloscene/pose.py
@@ -1,0 +1,19 @@
+from aloscene.tensors.augmented_tensor import AugmentedTensor
+
+
+class Pose(AugmentedTensor):
+    """Pose Tensor.
+
+    Parameters
+    ----------
+    x: torch.Tensor
+        Pose matrix
+    """
+
+    @staticmethod
+    def __new__(cls, x, *args, names=(None, None), **kwargs):
+        tensor = super().__new__(cls, x, *args, names=names, **kwargs)
+        return tensor
+
+    def __init__(self, x, *args, **kwargs):
+        super().__init__(x)


### PR DESCRIPTION
### Add  a mergeable pose label to the Frame object.
It can be used as such

```python
P = aloscene.Pose(cam_pos)
```
Pose directly inherit from CameraExtrinsic but usually refer to the global world coordinates/

### Fix noisy pos to propagate the normalization and to use the device properly.

### Add aloscene.render()

You can now directly render a list of view using aloscene.render()
```
aloscene.render(views)
```

Here is a example to add views and to record a video

```python
views = []
# Run DFM on side cameras

for frames in data_loader:

    # Build a list of view
    for frames_side in frames:
        output = model.inference(model(frames))
        views.append(output.get_view())
    
    # render the list
    aloscene.render(views, record_file="model_outputs.mp4")

# Save the final video
aloscene.save_renderer()
```
### batch list from aloscene

Instead of doing
```
SpatialAugmentedTensor.batch_list(tensors)
```
or 
```
tensors[0].batch_list(tensors)
```

You can now do:

```
aloscene.batch_list(tensors)
```

### Compute translation between two pose/extrinsic

```python
ref.pose.translation_with(src.pose)
```




