### PR TITLE
fix depth absolute/inverse assertion

### DIFF
--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -95,8 +95,9 @@ class BaseTRTExporter:
         if prod_package_error is not None:
             raise prod_package_error
 
-        if model is not None:
-            assert hasattr(model, "tracing") and model.tracing, "Model must be instantiated with tracing=True"
+        if hasattr(model, 'tracing'):
+            assert model.tracing, "Model must be instantiated with tracing=True"
+            
         self.model = model
         self.input_names = input_names
         self.onnx_path = onnx_path

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -41,10 +41,6 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             *args,
             names=("C", "H", "W"),
             **kwargs):
-        if is_absolute and not (shift and scale):
-            raise AttributeError('absolute depth requires shift and scale arguments')
-        if not is_absolute and (shift or scale):
-            raise AttributeError('depth not in inverse state, can not pass scale or shift')
         if isinstance(x, str):
             x = load_depth(x)
             names = ("C", "H", "W")


### PR DESCRIPTION
Instantiating Depth does not require any conditions now in term of scale/shift/absolute/not absolute. We let the user deal with the depth state and shift/scale attributes.