### PR TITLE
Conversion between distance and depth

### DIFF
--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -103,7 +103,7 @@ class CameraIntrinsic(AugmentedTensor):
         """
         frame_size: (H, W)
         """
-        # assert abs(self.skew) < 1e-3
+        assert abs(self.skew) < 1e-3
         cam_intrinsic = self.clone()
         cam_intrinsic[..., 0, 2] = frame_size[1] - cam_intrinsic[..., 0, 2]
         return cam_intrinsic
@@ -112,7 +112,7 @@ class CameraIntrinsic(AugmentedTensor):
         """
         frame_size: (H, W)
         """
-        # assert abs(self.skew) < 1e-3
+        assert abs(self.skew) < 1e-3
         cam_intrinsic = self.clone()
         cam_intrinsic[..., 1, 2] = frame_size[0] - cam_intrinsic[..., 1, 2]
         return cam_intrinsic

--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -103,7 +103,7 @@ class CameraIntrinsic(AugmentedTensor):
         """
         frame_size: (H, W)
         """
-        assert abs(self.skew) < 1e-3
+        # assert abs(self.skew) < 1e-3
         cam_intrinsic = self.clone()
         cam_intrinsic[..., 0, 2] = frame_size[1] - cam_intrinsic[..., 0, 2]
         return cam_intrinsic
@@ -112,7 +112,7 @@ class CameraIntrinsic(AugmentedTensor):
         """
         frame_size: (H, W)
         """
-        assert abs(self.skew) < 1e-3
+        # assert abs(self.skew) < 1e-3
         cam_intrinsic = self.clone()
         cam_intrinsic[..., 1, 2] = frame_size[0] - cam_intrinsic[..., 1, 2]
         return cam_intrinsic

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -81,7 +81,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> (undo_depth == not_absolute_depth).item()
         >>> True
         """
-        if not depth.is_absolute:
+        if not self.is_absolute:
             print('No need to inverse depth, already inversed')
             return self.clone()
         depth = self
@@ -130,7 +130,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> absolute_depth.is_absolute, not_absolute_depth.is_absolute
         >>> True, False
         """
-        if depth.is_absolute:
+        if self.is_absolute:
             print('Depth already in absolute value.')
             return self.clone()
         depth, names = self.rename(None), self.names

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -81,9 +81,10 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> (undo_depth == not_absolute_depth).item()
         >>> True
         """
-        depth = self
         if not depth.is_absolute:
-            raise ExecError('can not inverse depth, already inversed')
+            print('No need to inverse depth, already inversed')
+            return self
+        depth = self
         shift = depth.shift if depth.shift is not None else 0
         scale = depth.scale if depth.scale is not None else 1
 
@@ -129,9 +130,10 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         >>> absolute_depth.is_absolute, not_absolute_depth.is_absolute
         >>> True, False
         """
-        depth, names = self.rename(None), self.names
         if depth.is_absolute:
-            raise ExecError('depth already in absolute state, call encode_inverse first')
+            print('Depth already in absolute value.')
+            return self
+        depth, names = self.rename(None), self.names
 
         depth = depth * scale + shift
 

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -83,7 +83,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         """
         if not depth.is_absolute:
             print('No need to inverse depth, already inversed')
-            return self
+            return self.clone()
         depth = self
         shift = depth.shift if depth.shift is not None else 0
         scale = depth.scale if depth.scale is not None else 1
@@ -132,7 +132,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         """
         if depth.is_absolute:
             print('Depth already in absolute value.')
-            return self
+            return self.clone()
         depth, names = self.rename(None), self.names
 
         depth = depth * scale + shift
@@ -307,12 +307,12 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         -------
         aloscene.Depth
         """
-        planar = self
-        if not planar.is_planar:
+        if not self.is_planar:
             print("This tensor is already a euclidian depth tensor so no transform is performed")
-            return planar
+            return self.clone()
         assert projection in ["pinhole", "equidistant"], "Only pinhole and equidistant projection are supported"
 
+        planar = self
         camera_intrinsic = camera_intrinsic if camera_intrinsic is not None else self.cam_intrinsic
         if camera_intrinsic is None:
             err_msg = "The `camera_intrinsic` must be given either from the current depth tensor or from "
@@ -343,12 +343,12 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         -------
         aloscene.Depth
         """
-        euclidean = self
-        if euclidean.is_planar:
+        if self.is_planar:
             print("This tensor is already a planar depth tensor so no transform is done.")
-            return euclidean
+            return self.clone()
         assert projection in ["pinhole", "equidistant"], "Only pinhole and equidistant projection are supported"
 
+        euclidean = self
         camera_intrinsic = camera_intrinsic if camera_intrinsic is not None else self.cam_intrinsic
         if camera_intrinsic is None:
             err_msg = "The `camera_intrinsic` must be given either from the current depth tensor or from "

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -17,8 +17,8 @@ def coords2rtheta(K, size, distortion, projection="pinhole"):
         Projection model: Only pinhole and equidistant projection are supported.
     """
     h, w = size
-    focal = K.focal_length[0, 0]
-    principal_point = K.principal_points.permute((1, 0)).unsqueeze(-1)
+    focal = K.focal_length[..., 0]
+    principal_point = K.principal_points[..., :][:, None, None]
 
     coords = torch.meshgrid(torch.arange(h), torch.arange(w))
     coords = torch.stack(coords[::-1], dim=0).float().to(K.device)

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -1,0 +1,39 @@
+import torch
+from aloscene.tensors import AugmentedTensor
+
+
+def coords2rtheta(K, size, distortion, projection="pinhole"):
+    """Compute r_d and theta from image coordinates.
+
+    Parameters
+    ----------
+    K: aloscene.CameraIntrinsic
+        Intrinsic matrix of camera.
+    size: tuple
+        (H, W) height and width of image
+    distortion: float
+        Distortion coefficient using for wide angle camera.
+    projection: str
+        Projection model: Only pinhole and equidistant projection are supported.
+    """
+    h, w = size
+    focal = K.focal_length[0, 0]
+    principal_point = K.principal_points.permute((1, 0)).unsqueeze(-1)
+
+    coords = torch.meshgrid(torch.arange(h), torch.arange(w))
+    coords = torch.stack(coords[::-1], dim=0).float().to(K.device)
+    coords = coords - principal_point
+    r_d = coords[:2, ...] * coords[:2, ...]
+    r_d = torch.sqrt(torch.sum(r_d, dim=0, keepdim=True))
+
+    if projection == "pinhole":
+        theta = torch.atan(r_d / focal)
+    elif projection == "equidistant":
+        theta = r_d / (focal * distortion)
+    else:
+        raise NotImplementedError
+
+    theta = AugmentedTensor(theta, names=("C", "H", "W"))
+    r_d = AugmentedTensor(r_d, names=("C", "H", "W"))
+
+    return r_d, theta


### PR DESCRIPTION
> The shortest distance between two points is a straight line. - **Archimedes**

As said Archimedes, knowing the distance (straight line) between camera and a point is as important as knowing planar depth. Therefore, it's convenient to have methods that can do the conversion between them

**What's new ?** 

- Handle negative points in **encode_absolute**: For wide range camera (FoV > 180), it's possible to have points whose planar depth is small than 0 (points behind camera). To keep these points instead of clipping by 0, pass keep_negative=True in argument.
- Depth to distance **as_distance()**: Convert depth to distance. Only pinhole camera and linear equidistant camera are supported at this time.
-  Distance to depth **as_depth()**: Convert distance to depth.  Only pinhole camera and linear equidistant camera are supported at this time.
- Possible to create a tensor of Distance by passing is_distance=True at initialization.
- Support functions in depth_utils.

**Update**
-  Change the term to avoid the confusion: "euclidean depth" for distance and "planar depth" for usual depth.
- **as_distance()** becomes **as_euclidean()**
- **as_depth()** becomes **as_planar()**

> Archimedes's quote now becomes: _The shortest "euclidean depth" between two points is a straight line_.