### PR TITLE
add tensorrt quantization

### DIFF
--- a/alonet/torch2trt/TRTEngineBuilder.py
+++ b/alonet/torch2trt/TRTEngineBuilder.py
@@ -148,7 +148,10 @@ class TRTEngineBuilder:
                 config.set_flag(trt.BuilderFlag.FP16)
             # INT8
             if self.INT8_allowed:
-                raise NotImplementedError()
+                if not builder.platform_has_fast_int8:
+                    raise RuntimeError('INT8 not supported on this platform')
+                config.set_flag(trt.BuilderFlag.INT8)
+                config.int8_calibrator = self.calibrator
             if self.strict_type:
                 config.set_flag(trt.BuilderFlag.STRICT_TYPES)
             # Add optimization profile (used for dynamic shapes)

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -23,7 +23,7 @@ from contextlib import redirect_stdout, ExitStack
 from alonet.torch2trt.onnx_hack import scope_name_workaround, get_scope_names, rename_tensors_
 from alonet.torch2trt import TRTEngineBuilder, TRTExecutor, utils
 from alonet.torch2trt.utils import get_nodes_by_op, rename_nodes_
-
+from alonet.torch2trt.calibrator import BaseCalibrator
 
 
 class BaseTRTExporter:
@@ -54,7 +54,7 @@ class BaseTRTExporter:
         operator_export_type=None,
         dynamic_axes: Union[Dict[str, Dict[int, str]], Dict[str, List[int]]] = None,
         opt_profiles: Dict[str, Tuple[List[int]]] = None,
-        skip_adapt_graph=False,
+        calibrator: BaseCalibrator = None,
         **kwargs,
     ):
         """
@@ -110,7 +110,6 @@ class BaseTRTExporter:
         self.custom_opset = None  # to be redefine in child class if needed
         self.use_scope_names = use_scope_names
         self.operator_export_type = operator_export_type
-        self.skip_adapt_graph = skip_adapt_graph
         if dynamic_axes is not None:
             assert opt_profiles is not None, "If dynamic_axes are to be used, opt_profiles must be provided"
             assert isinstance(dynamic_axes, dict)
@@ -121,11 +120,6 @@ class BaseTRTExporter:
         onnx_file_name = os.path.split(onnx_path)[1]
         model_name = onnx_file_name.split(".")[0]
 
-        if not self.skip_adapt_graph:
-            self.adapted_onnx_path = os.path.join(onnx_dir, "trt_" + onnx_file_name)
-        else:
-            self.adapted_onnx_path = os.path.join(onnx_dir, onnx_file_name)
-
         self.engine_path = os.path.join(onnx_dir, model_name + f"_{precision.lower()}.engine")
 
         if self.verbose:
@@ -133,12 +127,15 @@ class BaseTRTExporter:
         else:
             trt_logger = trt.Logger(trt.Logger.WARNING)
 
-        self.engine_builder = TRTEngineBuilder(self.adapted_onnx_path, logger=trt_logger, opt_profiles=opt_profiles)
+        self.engine_builder = TRTEngineBuilder(self.onnx_path, logger=trt_logger, opt_profiles=opt_profiles, calibrator=calibrator)
 
         if precision.lower() == "fp32":
             pass
         elif precision.lower() == "fp16":
             self.engine_builder.FP16_allowed = True
+            self.engine_builder.strict_type = True
+        elif precision.lower() == "int8":
+            self.engine_builder.INT8_allowed = True
             self.engine_builder.strict_type = True
         elif precision.lower() == "mix":
             self.engine_builder.FP16_allowed = True
@@ -258,11 +255,9 @@ class BaseTRTExporter:
         else:
             with torch.no_grad():
                 m_outputs = self.model(*inputs, **kwargs)
-
             # Prepare inputs for torch.export.onnx and sanity check
             np_inputs = tuple(np.array(i.cpu()) for i in inputs)
         inputs = (*inputs, kwargs)
-
         onames = m_outputs._fields if hasattr(m_outputs, "_fields") else [f"out_{i}" for i in range(len(m_outputs))]
         np_m_outputs = {key: val.cpu().numpy() for key, val in zip(onames, m_outputs) if isinstance(val, torch.Tensor)}
         # print("Model input shapes:", [val.shape for val in np_inputs])
@@ -275,6 +270,7 @@ class BaseTRTExporter:
                 buffer = stack.enter_context(io.StringIO())
                 stack.enter_context(redirect_stdout(buffer))
                 stack.enter_context(scope_name_workaround())
+            
             torch.onnx.export(
                 self.model,  # model being run
                 inputs,  # model input (or a tuple for multiple inputs)
@@ -293,6 +289,16 @@ class BaseTRTExporter:
 
             if self.use_scope_names:
                 onnx_export_log = buffer.getvalue()
+            
+
+        graph = gs.import_onnx(onnx.load(self.onnx_path))
+        graph.toposort()
+
+        # === Modify ONNX graph for TensorRT compability
+        graph = self._adapt_graph(graph, **kwargs)
+        utils.print_graph_io(graph)
+        # === Export adapted onnx for TRT engine
+        onnx.save(gs.export_onnx(graph), self.onnx_path)
 
         # rewrite onnx graph with new scope names
         if self.use_scope_names:
@@ -318,16 +324,6 @@ class BaseTRTExporter:
         """
         if prod_package_error is not None:
             raise prod_package_error
-
-        if not self.skip_adapt_graph:
-            graph = gs.import_onnx(onnx.load(self.onnx_path))
-            graph.toposort()
-
-            # === Modify ONNX graph for TensorRT compability
-            graph = self._adapt_graph(graph, **kwargs)
-            utils.print_graph_io(graph)
-            # === Export adapted onnx for TRT engine
-            onnx.save(gs.export_onnx(graph), self.adapted_onnx_path)
 
         # === Build engine
         self.engine_builder.export_engine(self.engine_path)
@@ -387,7 +383,6 @@ class BaseTRTExporter:
             default=None,
             help="/path/onnx/will/be/exported, by default set as ~/.aloception/weights/MODEL/MODEL.onnx",
         )
-        parser.add_argument("--skip_adapt_graph", action="store_true", help="Skip the adapt graph")
         parser.add_argument("--batch_size", type=int, default=1, help="Engine batch size, default = 1")
         parser.add_argument("--precision", type=str, default="fp32", help="fp32/fp16/mix, default FP32")
         parser.add_argument("--verbose", action="store_true", help="Helpful when debugging")

--- a/alonet/torch2trt/calibrator.py
+++ b/alonet/torch2trt/calibrator.py
@@ -1,0 +1,154 @@
+import os
+import numpy as np
+import tensorrt as trt
+
+import pycuda.driver as cuda
+import pycuda.autoinit
+
+from aloscence.frame import Frame
+
+
+class DataBatchStreamer:
+    """Streams dataset in batches to the Calibrator
+
+    Parameters
+    ----------
+        dataset: (BaseDatset)
+            Dataset to stream. Default None.
+        batch_size: (int)
+            Streaming batch size. Default 8.
+        limit_batches: (int)
+            Maximum baches to use.
+    
+    Attributes
+    ----------
+        batch_idx: (int)
+            Current batch.
+        calib_ds: (np.ndarray)
+            Batch of data of calibration (size: (batch_size, C, H, W)).
+        max_batch: (int)
+            Number of batches used for calibration.
+
+    """
+    def __init__(
+            self,
+            dataset=None,
+            batch_size=8,
+            limit_batches=None,
+            ):
+        C, H, W = dataset[0].shape
+        self.batch_size = batch_size
+        self.batch_idx = 0
+        self.calib_ds = np.ones((batch_size, C, H, W))
+        self.dataset = dataset
+
+        dlength = len(self.dataset)
+        self.max_batch = dlength // batch_size + (1 if dlength % batch_size else 0)
+        if limit_batches is not None:
+            self.max_batch = min(self.max_batch, limit_batches)
+    
+    def reset(self):
+        self.batch_idx = 0
+    
+    def next_(self):
+        if self.batch_idx < self.max_batch:
+            bidx = self.batch_idx * self.batch_size
+            eidx = self.batch_idx * (self.batch_size + 1)
+            for i, j in enumerate(range(bidx, eidx)):
+                frame = self.dataset[j]
+                if isinstance(frame, Frame):
+                    frame = frame.as_numpy()
+                self.calib_ds[i] = frame
+
+            self.batch_idx += 1
+            return np.ascontiguousarray(self.calib_ds, dtype=np.float32)
+        
+        else:
+            return np.array([])
+
+
+class BaseCalibrator:
+    """Tensorrt data calibrator for post training quantization
+    
+    Parameters
+    ----------
+        data_streamer: (DataBatchStreamer)
+            data sreamer
+        cache_file: (str)
+            path to calibration cache file. Default None
+
+    
+    """
+    def __init__(
+            self,
+            data_streamer,
+            cache_file=None,
+        ):
+        self.cache_file = cache_file
+        self.data_streamer = data_streamer
+        self.d_input = cuda.mem_alloc(self.data_streamer.calib_ds.nbytes)
+        data_streamer.reset()
+
+    def get_batch_size(self):
+        return self.data_streamer.batch_size
+
+    def get_batch(self, names):
+        batch = self.data_streamer.next_()
+        if not batch.size:   
+            return None
+        
+        cuda.memcpy_htod(self.d_input, batch)
+        return [int(self.d_input)]
+         
+    def read_calibration_cache(self):
+        ## expilicitly returns None if cache file does not exist
+        if os.path.exists(self.cache_file):
+            with open(self.cache_file, 'rb') as f:
+                return f.read()
+
+    def write_calibration_cache(self, cache):
+        if self.cache_file in None:
+            return None
+
+        with open(self.cache_file, 'wb') as f:
+            f.write(cache)
+    
+
+class MinMaxCalibrator(BaseCalibrator, trt.IInt8MinMaxCalibrator):
+    def __init__(
+            self,
+            data_streamer,
+            cache_file,
+        ):
+        trt.IInt8MinMaxCalibrator.__init__(self)
+        super(MinMaxCalibrator, self).__init__(data_streamer=data_streamer, cache_file=cache_file)
+
+
+class LegacyCalibrator(BaseCalibrator, trt.IInt8LegacyCalibrator):
+    def __init__(
+            self,
+            data_streamer,
+            cache_file,
+        ):
+        trt.IInt8LegacyCalibrator.__init__(self)
+        super(LegacyCalibrator, self).__init__(data_streamer=data_streamer, cache_file=cache_file)
+
+
+class EntropyCalibrator(BaseCalibrator, trt.IInt8EntropyCalibrator):
+    def __init__(
+            self,
+            data_streamer,
+            cache_file,
+        ):
+        trt.IInt8EntropyCalibrator.__init__(self)
+        super(EntropyCalibrator, self).__init__(data_streamer=data_streamer, cache_file=cache_file)
+
+
+class EntropyCalibrator2(BaseCalibrator, trt.IInt8EntropyCalibrator2):
+    def __init__(
+            self,
+            data_streamer,
+            cache_file,
+        ):
+        trt.IInt8EntropyCalibrator2.__init__(self)
+        super(EntropyCalibrator2, self).__init__(data_streamer=data_streamer, cache_file=cache_file)

--- a/alonet/torch2trt/quantization.py
+++ b/alonet/torch2trt/quantization.py
@@ -1,0 +1,116 @@
+import torch
+import numpy as np
+import torch.nn as nn
+
+from pytorch_quantization import quant_modules
+from pytorch_quantization import nn as quant_nn
+from pytorch_quantization.tensor_quant import QuantDescriptor
+
+
+class QuantizedModel:
+    """Models quantization inteface : Transforms each model Layer to QuantLayer for quantization aware training
+    ConvTranspose2d ~ QuantConvTransposed2d, Conv2d ~ QuantConv2D, Linear ~ QuantLinear
+    
+    Parameters
+    ----------
+        calib_data: Iterable batched dataset
+            calibration data.
+        per_channel_quantization: bool.
+            either to quantize each channel or not.
+        method: str
+            method to use to compute maximum ("mse", "entropy", "max").
+        max_samples: int
+            maximum samples to use.
+    
+    Exemples
+    --------
+        >>> from ... import Model
+        >>> class QModel(QuantizedModel, Model):
+        .       def __init__(self, ..., **kwargs):
+        .           ## set QuantizedLayers description first
+        .           self.set_default_desc()
+        .           super(QModel).__init__(**kwargs)
+        >>> quant_model = QModel(...)
+        >>> quant_model.calibrate()
+        >>> print(quant_model.cuda())
+        
+    """
+    def __init__(
+            self,
+            calib_data,
+            method="max",
+            max_samples=20,
+            calib_method='histogram',
+            per_channel_quantization=True,
+            **kwargs,
+            ):
+        self.method = method
+        self.calib_data = calib_data
+        self.max_samples = max_samples
+        self.calib_method = calib_method
+        self.per_channel_quantization = per_channel_quantization
+    
+    def set_default_desc(self, calib_method='histogram', per_channel_quantization=True):
+        quant_desc_weight = QuantDescriptor(calib_method=calib_method)
+        if per_channel_quantization:
+            quant_desc_input = QuantDescriptor(calib_method=calib_method)
+        else:
+            quant_desc_input = QuantDescriptor(calib_method=calib_method, axis=None)
+
+        quant_nn.QuantConvTranspose2d.set_default_quant_desc_input(quant_desc_input)
+        quant_nn.QuantConvTranspose2d.set_default_quant_desc_weight(quant_desc_weight)
+
+        quant_nn.QuantConv2d.set_default_quant_desc_input(quant_desc_input)
+        quant_nn.QuantConv2d.set_default_quant_desc_weight(quant_desc_weight)
+
+        quant_nn.QuantLinear.set_default_quant_desc_input(quant_desc_input)
+        quant_nn.QuantLinear.set_default_quant_desc_weight(quant_desc_weight)
+
+        ## convert Layers to QuantLayers
+        quant_modules.initialize()
+
+        ## set fake quantization to True before torch2onnx
+        quant_nn.TensorQuantizer.use_fb_fake_quant = True
+    
+    def collect_stats(self):
+        """Feed data to the network and collect statistic"""
+        # Enable calibrators
+        for name, module in self.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    module.disable_quant()
+                    module.enable_calib()
+                else:
+                    module.disable()
+
+        for i, image in enumerate(self.calib_data): ## FIXME
+            if isinstance(image, np.ndarray):
+                image = np.expand_dims(image, axis=0)
+            self(image)
+            if i >= self.max_samples:
+                break
+
+        # Disable calibrators
+        for name, module in model.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    module.enable_quant()
+                    module.disable_calib()
+                else:
+                    module.enable()
+            
+    def compute_amax(self, **kwargs):
+        # Load calib result
+        for name, module in self.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    if isinstance(module._calibrator, calib.MaxCalibrator):
+                        module.load_calib_amax()
+                    else:
+                        module.load_calib_amax(**kwargs)
+
+    def calibrate(self):
+        """Calibrates the model"""
+        with torch.no_grad():
+            self.collect_stats()
+            self.compute_amax(method=self.method)


### PR DESCRIPTION
- New :collision: :

  - TensorRt engines can now be built with int8 precision using Post Training Quantization.
  - 4 calibrators are available for quantization : `MinMaxCalibrator`, `LegacyCalibrator`, `EntropyCalibrator` and `EntropyCalibrator2`.

- FIxed :wrench: :
  - adapt graph option is removed, we just adapt graph once it's exported from torch to onnx. 