### PR TITLE
fixed typo l.179

### DIFF
--- a/alonet/callbacks/metrics_callback.py
+++ b/alonet/callbacks/metrics_callback.py
@@ -176,7 +176,7 @@ class MetricsCallback(pl.Callback):
             )
 
         self._process_train_metrics(outputs)
-        if trainer.fit_loop.should_accumulate() or (trainer.global_step + 1) % trainer.log_every_n_steps != 0:
+        if trainer.fit_loop._should_accumulate() or (trainer.global_step + 1) % trainer.log_every_n_steps != 0:
             return
 
         self._log_train_metrics(pl_module, trainer)


### PR DESCRIPTION
FitLoop is a PytorchLightning class and its "should accumulate" method starts with a _, the metric doesn't work otherwise.
PL version : 1.5.10