### PR TITLE
SupportProjection model and distortion

### DIFF
--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -338,6 +338,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         -------
         aloscene.Depth
         """
+        projection = projection if projection is not None else self.projection
+        distortion = distortion if distortion is not None else self.distortion
+
         if not self.is_planar:
             print("This tensor is already a euclidian depth tensor so no transform is performed")
             return self.clone()
@@ -374,6 +377,9 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         -------
         aloscene.Depth
         """
+        projection = projection if projection is not None else self.projection
+        distortion = distortion if distortion is not None else self.distortion
+
         if self.is_planar:
             print("This tensor is already a planar depth tensor so no transform is done.")
             return self.clone()

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -171,19 +171,18 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
 
     def __get_view__(self, cmap="nipy_spectral", min_depth=0, max_depth=200, title=None, reverse=True, legend=False, min_legend=None, max_legend=None):
         assert all(dim not in self.names for dim in ["B", "T"]), "Depth should not have batch or time dimension"
-        cmap = matplotlib.cm.get_cmap(cmap)
+        cmap_m = matplotlib.cm.get_cmap(cmap)
         depth = self.rename(None).permute([1, 2, 0]).detach().cpu().contiguous().numpy()
-        v_min = np.min(depth)
-        v_max = np.max(depth)
         depth = matplotlib.colors.Normalize(vmin=min_depth, vmax=max_depth, clip=True)(depth)
         if reverse:
             depth = 1 - depth
-        depth_color = cmap(depth)[:, :, 0, :3]
+            cmap += "_r"
+        depth_color = cmap_m(depth)[:, :, 0, :3]
         if legend:
             if min_legend is None:
-                min_legend = v_min
+                min_legend = min_depth
             if max_legend is None:
-                max_legend = v_max
+                max_legend = max_depth
             depth_color = add_colorbar(depth_color, min_legend, max_legend, cmap)
 
         return View(depth_color, title=title)

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -40,6 +40,8 @@ class SpatialAugmentedTensor(AugmentedTensor):
         camera_side: str = None,
         baseline: float = None,
         mask=None,
+        projection="pinhole",
+        distortion=1.0,
         **kwargs,
     ):
         tensor = super().__new__(cls, x, *args, **kwargs)
@@ -47,6 +49,8 @@ class SpatialAugmentedTensor(AugmentedTensor):
         tensor.add_child("mask", mask, align_dim=["B", "T"], mergeable=True)
         tensor.add_property("baseline", baseline)
         tensor.add_property("camera_side", camera_side)
+        tensor.add_property("projection", projection)
+        tensor.add_property("distortion", distortion)
 
         # Intrisic and extrinsic parameters are cloned by default, to prevent having multiple reference
         # of the same intrisic/extrinsic across nodes.

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -18,7 +18,10 @@ def coords2rtheta(K, size, distortion, projection="pinhole"):
     """
     h, w = size
     focal = K.focal_length[..., 0]
-    principal_point = K.principal_points[..., :][:, None, None]
+    principal_point = K.principal_points[..., :]
+    if len(principal_point.shape) > 1:
+        principal_point = principal_point[0, :]
+    principal_point = principal_point[:, None, None]
 
     coords = torch.meshgrid(torch.arange(h), torch.arange(w))
     coords = torch.stack(coords[::-1], dim=0).float().to(K.device)

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -1,5 +1,7 @@
 import torch
 from aloscene.tensors import AugmentedTensor
+import matplotlib.pyplot as plt
+import numpy as np
 
 
 def coords2rtheta(K, size, distortion, projection="pinhole"):
@@ -40,3 +42,17 @@ def coords2rtheta(K, size, distortion, projection="pinhole"):
     r_d = AugmentedTensor(r_d, names=("C", "H", "W"))
 
     return r_d, theta
+
+
+def add_colorbar(data, vmin, vmax, colormap):
+    fig = plt.figure()
+    pos = plt.imshow(data, cmap=colormap, interpolation='none')
+    plt.axis('off')
+    fig.colorbar(pos)
+    pos.set_clim(vmin=vmin, vmax=vmax)
+    fig.tight_layout(pad=0)
+    fig.canvas.draw()
+    data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,)) / 255.
+
+    return data


### PR DESCRIPTION
**New feature**
- Add projection and distortion as new properties of `SpatialAugmentedTensor` so that we can inherit for other types of tensor. Two projection models are supported: `pinhole` and `equidistant`. Default values are `pinhole` and `1.0` for distortion so it won't change anything for initialization if we are working on "pinhole" image. Only `aloscene.Depth` is supported for distortion and equidistant projection at this time.
- `Depth.as_points3d` is now supported equidistant model with distortion. If no projection model and distortion are specified in arguments, `as_points3d` uses the `projection` and `distortion` property.
- `Depth.as_planar` and `Depth.as_euclidean` now use `projection` and `distortion` property if there is no projection model and distortion specified in arguments.
-  `Depth.__get_view__` now can have color legend if `legend` is set `True`.