### PR TITLE
add profiling verbosity 

### DIFF
--- a/alonet/torch2trt/TRTEngineBuilder.py
+++ b/alonet/torch2trt/TRTEngineBuilder.py
@@ -33,6 +33,7 @@ class TRTEngineBuilder:
         calibrator: bool = None,
         logger=None,
         opt_profiles: Dict[str, Tuple[List[int]]] = None,
+        profiling_verbosity: str = "LAYER_NAMES_ONLY",
     ):
         """
         Parameters
@@ -71,6 +72,7 @@ class TRTEngineBuilder:
             assert isinstance(opt_profiles, dict)
             assert all([len(op) == 3 for op in opt_profiles.values()]), "Each profile must be a set of min/opt/max"
         self.opt_profiles = opt_profiles
+        self.profiling_verbosity = profiling_verbosity
 
     def set_workspace_size(self, workspace_size_GiB: int):
         self.max_workspace_size = GiB(workspace_size_GiB)
@@ -143,6 +145,15 @@ class TRTEngineBuilder:
             builder.max_batch_size = 1
             config = builder.create_builder_config()
             config.max_workspace_size = self.max_workspace_size
+            # Setting the profiling verbosity
+            if self.profiling_verbosity == "LAYER_NAMES_ONLY":
+                pass
+            elif self.profiling_verbosity == "DETAILED":
+                config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
+            elif self.profiling_verbosity == "NONE":
+                config.profiling_verbosity = trt.ProfilingVerbosity.NONE
+            else:
+                raise AttributeError("unknown profiling_verbosity")
             # FP16
             if self.FP16_allowed:
                 config.set_flag(trt.BuilderFlag.FP16)

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -408,6 +408,15 @@ class BaseTRTExporter:
         parser.add_argument("--precision", type=str, default="fp32", help="fp32/fp16/mix, default FP32")
         parser.add_argument("--verbose", action="store_true", help="Helpful when debugging")
         parser.add_argument("--profiling_verbosity", default=0, type=int, help="Helpful when profiling the engine")
+        parser.add_argument("--calibration_batch_size", type=int, default=8, help="Calibration data batch size.")
+        parser.add_argument("--limit_calibration_batches", type=int, default=10, help="Limits number of batches.")
+        parser.add_argument("--cache_file", type=str, default="calib.bin", help="Path to caliaration cache file.")
+        parser.add_argument(
+            "--calibrator", 
+            type=str, 
+            choices=['base', 'minmax', 'entropy', 'entropy2', 'legacy'], 
+            default='minmax',
+            help="Calibrator to use with int8 precision.")
         parser.add_argument(
             "--use_scope_names",
             action="store_true",

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -103,8 +103,8 @@ class BaseTRTExporter:
         if prod_package_error is not None:
             raise prod_package_error
 
-        if hasattr(model, 'tracing'):
-            assert model.tracing, "Model must be instantiated with tracing=True"
+        # if hasattr(model, 'tracing'):
+        #     assert model.tracing, "Model must be instantiated with tracing=True"
             
         self.model = model
         self.input_names = input_names
@@ -287,7 +287,6 @@ class BaseTRTExporter:
                 buffer = stack.enter_context(io.StringIO())
                 stack.enter_context(redirect_stdout(buffer))
                 stack.enter_context(scope_name_workaround())
-            
             torch.onnx.export(
                 self.model,  # model being run
                 inputs,  # model input (or a tuple for multiple inputs)
@@ -403,16 +402,16 @@ class BaseTRTExporter:
         parser.add_argument("--batch_size", type=int, default=1, help="Engine batch size, default = 1")
         parser.add_argument("--precision", type=str, default="fp32", help="fp32/fp16/mix, default FP32")
         parser.add_argument("--verbose", action="store_true", help="Helpful when debugging")
-        parser.add_argument("--profiling_verbosity", default=0, type=int, help="Helpful when profiling the engine")
-        parser.add_argument("--calibration_batch_size", type=int, default=8, help="Calibration data batch size.")
-        parser.add_argument("--limit_calibration_batches", type=int, default=10, help="Limits number of batches.")
-        parser.add_argument("--cache_file", type=str, default="calib.bin", help="Path to caliaration cache file.")
+        parser.add_argument("--profiling_verbosity", default=0, type=int, help="Helpful when profiling the engine (default: %(default)s)")
+        parser.add_argument("--calibration_batch_size", type=int, default=8, help="Calibration data batch size (default: %(default)s)")
+        parser.add_argument("--limit_calibration_batches", type=int, default=10, help="Limits number of batches (default: %(default)s)")
+        parser.add_argument("--cache_file", type=str, default="calib.bin", help="Path to caliaration cache file (default: %(default)s)")
         parser.add_argument(
             "--calibrator", 
             type=str, 
             choices=['base', 'minmax', 'entropy', 'entropy2', 'legacy'], 
             default='minmax',
-            help="Calibrator to use with int8 precision.")
+            help="Calibrator to use with int8 precision (default: %(default)s)")
         parser.add_argument(
             "--use_scope_names",
             action="store_true",

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -103,8 +103,8 @@ class BaseTRTExporter:
         if prod_package_error is not None:
             raise prod_package_error
 
-        # if hasattr(model, 'tracing'):
-        #     assert model.tracing, "Model must be instantiated with tracing=True"
+        if hasattr(model, 'tracing'):
+            assert model.tracing, "Model must be instantiated with tracing=True"
             
         self.model = model
         self.input_names = input_names

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -23,7 +23,6 @@ from contextlib import redirect_stdout, ExitStack
 from alonet.torch2trt.onnx_hack import scope_name_workaround, get_scope_names, rename_tensors_
 from alonet.torch2trt import TRTEngineBuilder, TRTExecutor, utils
 from alonet.torch2trt.utils import get_nodes_by_op, rename_nodes_
-from alonet.torch2trt.calibrator import BaseCalibrator
 
 
 class BaseTRTExporter:
@@ -54,8 +53,8 @@ class BaseTRTExporter:
         operator_export_type=None,
         dynamic_axes: Union[Dict[str, Dict[int, str]], Dict[str, List[int]]] = None,
         opt_profiles: Dict[str, Tuple[List[int]]] = None,
-        calibrator: BaseCalibrator = None,
         profiling_verbosity: int = 0,
+        calibrator=None,
         **kwargs,
     ):
         """
@@ -86,6 +85,8 @@ class BaseTRTExporter:
             Optimization profiles (one by each dynamic axis).
         operator_export_type: torch.onnx.OperatorExportTypes
             TODO
+        calibrator : torch2trt.calibrator.BaseCalibrator
+            Quantization calibrator.
         profiling_verbosity : int
             Profiling verbosity in NVTX annotations and the engine inspector (Default 0)
                 0 : LAYER_NAMES_ONLY (Print only the layer names. This is the default setting).

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -25,8 +25,6 @@ from alonet.torch2trt import TRTEngineBuilder, TRTExecutor, utils
 from alonet.torch2trt.utils import get_nodes_by_op, rename_nodes_
 from alonet.torch2trt.calibrator import BaseCalibrator
 
-from pytorch_quantization import nn as quant_nn
-
 
 class BaseTRTExporter:
     """
@@ -151,8 +149,6 @@ class BaseTRTExporter:
         if precision.lower() == "fp32":
             pass
         elif precision.lower() == "int8":
-            ## set fake quantization to True before torch2onnx
-            quant_nn.TensorQuantizer.use_fb_fake_quant = True
             self.engine_builder.INT8_allowed = True
             self.engine_builder.FP16_allowed = True
             self.engine_builder.strict_type = True

--- a/alonet/torch2trt/calibrator.py
+++ b/alonet/torch2trt/calibrator.py
@@ -90,7 +90,7 @@ class DataBatchStreamer:
         self.calib_ds = [np.ones((batch_size, *shapes[i])) for i in range(self.n_inputs)]
 
         self.dlength = len(dataset)
-        self.max_batch = dlength // batch_size + (1 if dlength % batch_size else 0)
+        self.max_batch = self.dlength // batch_size + (1 if self.dlength % batch_size else 0)
         if limit_batches is not None:
             self.max_batch = min(self.max_batch, limit_batches)
     

--- a/alonet/torch2trt/quantization.py
+++ b/alonet/torch2trt/quantization.py
@@ -81,6 +81,9 @@ class QuantizedModel:
         ## convert Layers to QuantLayers
         quant_modules.initialize()
 
+        ## set fake quantization to True before torch2onnx
+        quant_nn.TensorQuantizer.use_fb_fake_quant = True
+
     def collect_stats(self, calib_data, max_samples=None):
         """Feed data to the network and collect statistic
         


### PR DESCRIPTION
New :star: : 
- `profiling_verbosity` option is added to the TRTEngineBuilder to better inspect the details of each node when calling the `tensorrt.EngineInspector`
- Some quantization related arguments are added to the `BaseTRTExporter`.