### PR TITLE
fix masking dimension mismatch

### DIFF
--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -302,7 +302,9 @@ class AugmentedTensor(torch.Tensor):
                 )
 
         if isinstance(idx, torch.Tensor):
-            tensor = torch.Tensor.__getitem__(self.rename(None), idx).reset_names()
+            if not all(e in [0, 1] for e in idx.unique().int()): 
+                raise IndexError(f"Unvalid mask. Expected mask elements to be in [0, 1, True, False]")
+            tensor = self * idx
         else:
             tensor = torch.Tensor.__getitem__(self, idx)
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -302,8 +302,9 @@ class AugmentedTensor(torch.Tensor):
                 )
 
         if isinstance(idx, torch.Tensor):
-            if not all(e in [0, 1] for e in idx.unique().int()): 
-                raise IndexError(f"Unvalid mask. Expected mask elements to be in [0, 1, True, False]")
+            if not idx.dtype == torch.bool:
+                if torch.equal(idx ** 3, idx):
+                    raise IndexError(f"Unvalid mask. Expected mask elements to be in [0, 1, True, False]")
             tensor = self * idx
         else:
             tensor = torch.Tensor.__getitem__(self, idx)

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -303,7 +303,7 @@ class AugmentedTensor(torch.Tensor):
 
         if isinstance(idx, torch.Tensor):
             if not idx.dtype == torch.bool:
-                if torch.equal(idx ** 3, idx):
+                if not torch.equal(idx ** 3, idx):
                     raise IndexError(f"Unvalid mask. Expected mask elements to be in [0, 1, True, False]")
             tensor = self * idx
         else:


### PR DESCRIPTION
Fix :wrench: : AugmentedTensor can be masked without any need to expand the mask dimensions. 