### PR TITLE
allow user to complety specify the grid view

### DIFF
--- a/aloscene/__init__.py
+++ b/aloscene/__init__.py
@@ -17,19 +17,24 @@ from .tensors.spatial_augmented_tensor import SpatialAugmentedTensor
 
 from .renderer import Renderer
 
+
 def batch_list(tensors):
     return SpatialAugmentedTensor.batch_list(tensors)
 
+
 _renderer = None
+
+
 def render(
-        views: list,
-        renderer: str = "cv",
-        size=None,
-        record_file: str = None,
-        fps=30,
-        grid_size=None,
-        skip_views=False,
-    ):
+    views: list,
+    renderer: str = "cv",
+    size=None,
+    record_file: str = None,
+    fps=30,
+    grid_size=None,
+    skip_views=False,
+    **kwargs,
+):
     """Render a list of view.
 
     Parameters
@@ -57,7 +62,8 @@ def render(
         record_file=record_file,
         fps=fps,
         grid_size=grid_size,
-        skip_views=skip_views
+        skip_views=skip_views,
+        **kwargs,
     )
 
 

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -178,6 +178,18 @@ class Renderer(object):
 
     @staticmethod
     def add_title(array, start, title):
+        """
+        Add a box with view title
+
+        Parameters
+        ----------
+        array : np.ndarray
+            grid view array (will be modified inplace)
+        start : tuple
+            top-left corner of title box
+        title : str
+            title of the view
+        """
         if title is None:
             return
         else:


### PR DESCRIPTION
Add `from_list_of_list` argument to `Renderer.get_view()`. 

This allows the user to give a list of list of views, defining the 2D grid of views.
All views keep their original shape, and are top-left aligned in their rows.

# Example
```
# Create three gray frames, display them on two rows (2 on first rows, 1 on 2nd row)
import numpy as np
import aloscene
arrays = [np.full((3, 600, 650), 100), np.full((3, 500, 500), 50), np.full((3, 500, 800), 200)]
frames = [aloscene.Frame(arr) for arr in arrays]
views = [[frames[0].get_view(), frames[1].get_view()], [frames[2].get_view()]]
aloscene.render(views, renderer="matplotlib")
```