### PR TITLE
add create_calibrator function

### DIFF
--- a/alonet/torch2trt/__init__.py
+++ b/alonet/torch2trt/__init__.py
@@ -2,6 +2,7 @@ from .TRTEngineBuilder import TRTEngineBuilder
 from .TRTExecutor import TRTExecutor
 from .base_exporter import BaseTRTExporter
 from .utils import load_trt_custom_plugins, create_calibrator
+from .calibrator import DataBatchStreamer
 
 from alonet import ALONET_ROOT
 import os

--- a/alonet/torch2trt/__init__.py
+++ b/alonet/torch2trt/__init__.py
@@ -1,10 +1,11 @@
 from .TRTEngineBuilder import TRTEngineBuilder
 from .TRTExecutor import TRTExecutor
 from .base_exporter import BaseTRTExporter
-from .utils import load_trt_custom_plugins
+from .utils import load_trt_custom_plugins, create_calibrator
 
 from alonet import ALONET_ROOT
 import os
+
 
 MS_DEFORM_IM2COL_PLUGIN_LIB = os.path.join(
     ALONET_ROOT, "torch2trt/plugins/ms_deform_im2col/build/libms_deform_im2col_trt.so"

--- a/alonet/torch2trt/calibrator.py
+++ b/alonet/torch2trt/calibrator.py
@@ -1,12 +1,10 @@
+from aloscene.frame import Frame
+
 import os
 import torch
 import numpy as np
 import tensorrt as trt
-
 import pycuda.driver as cuda
-import pycuda.autoinit
-
-from aloscene.frame import Frame
 
 
 class DataBatchStreamer:

--- a/alonet/torch2trt/utils.py
+++ b/alonet/torch2trt/utils.py
@@ -1,4 +1,13 @@
+from alonet import ALONET_ROOT
+from alonet.torch2trt.calibrator import (
+    LegacyCalibrator, 
+    MinMaxCalibrator,
+    EntropyCalibrator,
+    EntropyCalibrator2,
+)
+
 import os
+import ctypes
 
 try:
     import pycuda.driver as cuda
@@ -10,8 +19,25 @@ except Exception as prod_package_error:
     pass
 
 
-import ctypes
-from alonet import ALONET_ROOT
+def create_calibrator(name: str, *args, **kwargs):
+    """Creates calibrator from name
+
+    Parameters
+    ----------
+        name : str
+            Calibrator name
+    """
+    CALIBS = ["minmax", "entropy", "entropy2", "legacy"]
+    if name == "entropy2":
+        return EntropyCalibrator2(*args, **kwargs)
+    elif name == "entropy":
+        return EntropyCalibrator(*args, **kwargs)
+    elif name == "minmax":
+        return MinMaxCalibrator(*args, **kwargs)
+    elif name == "legacy":
+        return LegacyCalibrator(*args, **kwargs)
+    else:
+        raise AttributeError(f"Unknown calibrator name, should be one of {' '.join(CALIBS)}")
 
 
 def load_trt_custom_plugins(lib_path: str):


### PR DESCRIPTION
***New feature*** : `create_calibrator` function that allows to create calibrator from name and kwargs is added to alonet.torch2trt to optimize imports in Tensorrt scripts.
```python
from alonet.torch2trt import create_calibrator, DataBatchStreamer

cache_file = "calib.bin"
data_streamer = DataBatchStreamer(...)

calibrator = create_calibrator("minmax", data_streamer, cache_file)
```
_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
